### PR TITLE
record exact timestamp when usage data is enqueued

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataStore.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataStore.java
@@ -13,6 +13,7 @@ package com.microsoft.java.debug.core;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -87,10 +88,13 @@ public class UsageDataStore {
         enqueue(errorEntry);
     }
 
-    private synchronized void enqueue(Object object) {
+    private synchronized void enqueue(Map<String, String> entry) {
         if (queue.size() > QUEUE_MAX_SIZE) {
             queue.poll();
         }
-        queue.add(object);
+        if (entry != null) {
+            entry.put("timestamp", Instant.now().toString());
+            queue.add(entry);
+        }
     }
 }


### PR DESCRIPTION
related feature: https://github.com/Microsoft/vscode-java-debug/issues/74

The default `timestamp` is specified in lib `applicationinsights`, we cannot overwrite it, thus add a new one under customDimensions.

For an entry enqueued at 09:03:08, but collected by VSCode at 09:03:33, see the differences between `timestamp` and `customDimensions.timestamp`.

![image](https://user-images.githubusercontent.com/2351748/30958460-cb8501b0-a46f-11e7-9c36-79eddbffea46.png)
