### PR TITLE
fix java.lang.NullPointerException bug

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
@@ -27,7 +27,6 @@ import com.microsoft.java.debug.core.adapter.Messages.Response;
 import com.sun.jdi.event.Event;
 
 public class UsageDataSession {
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private static final Logger usageDataLogger = Logger.getLogger(Configuration.USAGE_DATA_LOGGER_NAME);
     private static final long RESPONSE_MAX_DELAY_MS = 1000;
     private static final ThreadLocal<UsageDataSession> threadLocal = new InheritableThreadLocal<>();
@@ -42,7 +41,7 @@ public class UsageDataSession {
     private List<String> eventList = new ArrayList<>();
 
     public static String getSessionGuid() {
-        return threadLocal.get().sessionGuid;
+        return threadLocal.get() == null ? "" : threadLocal.get().sessionGuid;
     }
 
     public UsageDataSession() {
@@ -155,7 +154,7 @@ public class UsageDataSession {
                 currentSession.eventList.add(JsonUtils.toJson(eventEntry));
             }
         } catch (Exception e) {
-            logger.log(Level.SEVERE, String.format("Exception on recording event: %s.", e.toString()), e);
+            Log.error(e, "Exception on recording event: %s.", e.toString());
         }
     }
 
@@ -169,7 +168,7 @@ public class UsageDataSession {
                 currentSession.jdiEventSequenceEnabled = true;
             }
         } catch (Exception e) {
-            // ignore it
+            Log.error(e, "Exception on enableJdiEventSequence: %s.", e.toString());
         }
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
@@ -27,6 +27,7 @@ import com.microsoft.java.debug.core.adapter.Messages.Response;
 import com.sun.jdi.event.Event;
 
 public class UsageDataSession {
+    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private static final Logger usageDataLogger = Logger.getLogger(Configuration.USAGE_DATA_LOGGER_NAME);
     private static final long RESPONSE_MAX_DELAY_MS = 1000;
     private static final ThreadLocal<UsageDataSession> threadLocal = new InheritableThreadLocal<>();
@@ -154,7 +155,7 @@ public class UsageDataSession {
                 currentSession.eventList.add(JsonUtils.toJson(eventEntry));
             }
         } catch (Exception e) {
-            Log.error(e, "Exception on recording event: %s.", e.toString());
+            logger.log(Level.SEVERE, String.format("Exception on recording event: %s.", e.toString()), e);
         }
     }
 
@@ -168,7 +169,7 @@ public class UsageDataSession {
                 currentSession.jdiEventSequenceEnabled = true;
             }
         } catch (Exception e) {
-            Log.error(e, "Exception on enableJdiEventSequence: %s.", e.toString());
+            // ignore it
         }
     }
 }


### PR DESCRIPTION
[Error - 3:28:50 PM] Oct 12, 2017 3:27:33 PM Problems occurred when invoking code from plug-in: "org.eclipse.jdt.ls.core".
null
java.lang.NullPointerException
    at com.microsoft.java.debug.core.UsageDataSession.getSessionGuid(UsageDataSession.java:45)
    at com.microsoft.java.debug.core.UsageDataStore.logErrorData(UsageDataStore.java:84)
    at com.microsoft.java.debug.plugin.internal.UsageDataLogHandler.publish(UsageDataLogHandler.java:34)
    at java.util.logging.Logger.log(Logger.java:738)
    at java.util.logging.Logger.doLog(Logger.java:765)
    at java.util.logging.Logger.log(Logger.java:876)
    at com.microsoft.java.debug.plugin.internal.ResolveClasspathsHandler.resolveClasspaths(ResolveClasspathsHandler.java:52)
    at com.microsoft.java.debug.plugin.internal.JavaDebugDelegateCommandHandler.executeCommand(JavaDebugDelegateCommandHandler.java:42)
    at org.eclipse.jdt.ls.core.internal.handlers.WorkspaceExecuteCommandHandler$1.run(WorkspaceExecuteCommandHandler.java:133)
    at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
    at org.eclipse.jdt.ls.core.internal.handlers.WorkspaceExecuteCommandHandler.executeCommand(WorkspaceExecuteCommandHandler.java:128)
    at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.lambda$2(JDTLanguageServer.java:250)
    at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602)