### PR TITLE
We should not send error message after termination to vscode because …

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
@@ -68,8 +68,7 @@ public class DebugAdapter implements IDebugAdapter {
 
         try {
             if (debugContext.isVmTerminated()) {
-                AdapterUtils.setErrorResponse(response, ErrorCode.VM_TERMINATED,
-                        String.format("Target VM is already terminated.", request.command));
+                // the operation is meaningless
                 return response;
             }
             List<IDebugRequestHandler> handlers = requestHandlers.get(command);


### PR DESCRIPTION
…we don't want to show user with such errors.

https://github.com/Microsoft/vscode-java-debug/issues/91