### PR TITLE
Avoid two stopped events for step and breakpoint

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugEvent.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugEvent.java
@@ -12,8 +12,10 @@
 package com.microsoft.java.debug.core;
 
 import com.sun.jdi.event.Event;
+import com.sun.jdi.event.EventSet;
 
 public class DebugEvent {
     public Event event = null;
+    public EventSet eventSet = null;
     public boolean shouldResume = true;
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EventHub.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EventHub.java
@@ -74,6 +74,7 @@ public class EventHub implements IEventHub {
                         }
                         DebugEvent dbgEvent = new DebugEvent();
                         dbgEvent.event = event;
+                        dbgEvent.eventSet = set;
                         subject.onNext(dbgEvent);
                         shouldResume &= dbgEvent.shouldResume;
                     }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

fix bug https://github.com/Microsoft/vscode-java-debug/issues/14