### PR TITLE
Auto add correlationId in usage data

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/AmbientContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/AmbientContext.java
@@ -9,7 +9,7 @@
 *     Microsoft Corporation - initial API and implementation
 *******************************************************************************/
 
-package com.microsoft.java.debug.core.trace;
+package com.microsoft;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class AmbientContext extends ConcurrentHashMap<String, Object> {
     public static final String AMBCTX_ID = AmbientContext.class.getSimpleName() + "Id";
-    static InheritableThreadLocal<AmbientContext> callContext = new InheritableThreadLocal<AmbientContext>() {
+    static InheritableThreadLocal<AmbientContext> inheritableThreadLocal = new InheritableThreadLocal<AmbientContext>() {
         @Override
         protected AmbientContext initialValue() {
             return null;
@@ -58,7 +58,7 @@ public class AmbientContext extends ConcurrentHashMap<String, Object> {
     }
 
     public static void removeAmbientContext() {
-        callContext.remove();
+        inheritableThreadLocal.remove();
     }
 
     /**
@@ -66,12 +66,12 @@ public class AmbientContext extends ConcurrentHashMap<String, Object> {
      */
     public static AmbientContext initializeAmbientContext(AmbientContext rawContext) {
         AmbientContext context = (rawContext != null) ? rawContext : new AmbientContext();
-        callContext.set(context);
+        inheritableThreadLocal.set(context);
         return context;
     }
 
     public static AmbientContext tryGetCurrentContext() {
-        return callContext.get();
+        return inheritableThreadLocal.get();
     }
 
     /**

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
@@ -20,18 +20,18 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.google.gson.JsonElement;
+import com.microsoft.AmbientContext;
 import com.microsoft.java.debug.core.adapter.AdapterUtils;
 import com.microsoft.java.debug.core.protocol.JsonUtils;
 import com.microsoft.java.debug.core.protocol.Messages.Request;
 import com.microsoft.java.debug.core.protocol.Messages.Response;
-import com.microsoft.java.debug.core.trace.AmbientContext;
 import com.sun.jdi.event.Event;
 
 public class UsageDataSession {
     private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private static final Logger usageDataLogger = Logger.getLogger(Configuration.USAGE_DATA_LOGGER_NAME);
     private static final long RESPONSE_MAX_DELAY_MS = 1000;
-    private static final String AMBCTX_USAGE_DATA_SESSION = "UsageDataSession";
+    private static final String AMBIENT_CONTEXT_USAGE_DATA_SESSION = "UsageDataSession";
 
     private final String sessionGuid = UUID.randomUUID().toString();
     private boolean jdiEventSequenceEnabled = false;
@@ -47,7 +47,8 @@ public class UsageDataSession {
      */
     public static String getSessionGuid() {
         AmbientContext context = AmbientContext.tryGetCurrentContext();
-        return context != null && context.get(AMBCTX_USAGE_DATA_SESSION) != null ? ((UsageDataSession) context.get(AMBCTX_USAGE_DATA_SESSION)).sessionGuid : "";
+        return context != null && context.get(AMBIENT_CONTEXT_USAGE_DATA_SESSION) != null
+                ? ((UsageDataSession) context.get(AMBIENT_CONTEXT_USAGE_DATA_SESSION)).sessionGuid : "";
     }
 
     /**
@@ -56,7 +57,7 @@ public class UsageDataSession {
     public UsageDataSession() {
         AmbientContext context = AmbientContext.tryGetCurrentContext();
         if (context != null) {
-            context.put(AMBCTX_USAGE_DATA_SESSION, this);
+            context.put(AMBIENT_CONTEXT_USAGE_DATA_SESSION, this);
         }
     }
 
@@ -160,7 +161,7 @@ public class UsageDataSession {
      */
     public static void recordEvent(Event event) {
         try {
-            UsageDataSession currentSession = (UsageDataSession) AmbientContext.currentContext().get(AMBCTX_USAGE_DATA_SESSION);
+            UsageDataSession currentSession = (UsageDataSession) AmbientContext.currentContext().get(AMBIENT_CONTEXT_USAGE_DATA_SESSION);
             if (currentSession != null) {
                 Map<String, String> eventEntry = new HashMap<>();
                 eventEntry.put("timestamp", String.valueOf(System.currentTimeMillis()));
@@ -179,7 +180,7 @@ public class UsageDataSession {
      */
     public static void enableJdiEventSequence() {
         try {
-            UsageDataSession currentSession = (UsageDataSession) AmbientContext.currentContext().get(AMBCTX_USAGE_DATA_SESSION);
+            UsageDataSession currentSession = (UsageDataSession) AmbientContext.currentContext().get(AMBIENT_CONTEXT_USAGE_DATA_SESSION);
             if (currentSession != null) {
                 currentSession.jdiEventSequenceEnabled = true;
             }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataStore.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataStore.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import com.microsoft.java.debug.core.protocol.JsonUtils;
+import com.microsoft.java.debug.core.trace.AmbientContext;
 
 public class UsageDataStore {
     private ConcurrentLinkedQueue<Object> queue;
@@ -27,6 +28,7 @@ public class UsageDataStore {
     private static final String STACKTRACE_NAME = "stackTrace";
     private static final String SCOPE_NAME = "scope";
     private static final String TIMESTAMP_NAME = "timestamp";
+    private static final String CORRELATION_ID_NAME = "correlationId";
 
     /**
      * Constructor.
@@ -69,6 +71,7 @@ public class UsageDataStore {
         if (props != null) {
             sessionEntry.putAll(props);
         }
+        attachCorrelationId(sessionEntry);
         enqueue(sessionEntry);
     }
 
@@ -89,6 +92,7 @@ public class UsageDataStore {
             errorEntry.put(ERROR_MESSAGE_NAME, th.getMessage());
             errorEntry.put(STACKTRACE_NAME, JsonUtils.toJson(th.getStackTrace()));
         }
+        attachCorrelationId(errorEntry);
         enqueue(errorEntry);
     }
 
@@ -99,6 +103,13 @@ public class UsageDataStore {
         if (entry != null) {
             entry.put(TIMESTAMP_NAME, Instant.now().toString());
             queue.add(entry);
+        }
+    }
+
+    private void attachCorrelationId(Map<String, String> props) {
+        AmbientContext context = AmbientContext.tryGetCurrentContext();
+        if (context != null) {
+            props.put(CORRELATION_ID_NAME, context.getId());
         }
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataStore.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataStore.java
@@ -16,8 +16,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import com.microsoft.AmbientContext;
 import com.microsoft.java.debug.core.protocol.JsonUtils;
-import com.microsoft.java.debug.core.trace.AmbientContext;
 
 public class UsageDataStore {
     private ConcurrentLinkedQueue<Object> queue;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/trace/AmbientContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/trace/AmbientContext.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright (c) 2017 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package com.microsoft.java.debug.core.trace;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AmbientContext extends ConcurrentHashMap<String, Object> {
+    public static final String AMBCTX_ID = AmbientContext.class.getSimpleName() + "Id";
+    static InheritableThreadLocal<AmbientContext> callContext = new InheritableThreadLocal<AmbientContext>() {
+        @Override
+        protected AmbientContext initialValue() {
+            return null;
+        }
+    };
+    private String id;
+    private AtomicLong count = new AtomicLong(0);
+
+    /**
+     * Constructor.
+     */
+    public AmbientContext() {
+        super();
+        id = UUID.randomUUID().toString();
+        put(AMBCTX_ID, id);
+    }
+
+    /**
+     * Copy constructor.
+     */
+    public AmbientContext(AmbientContext context) {
+        super(context);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * current Context.
+     */
+    public static AmbientContext currentContext() {
+        AmbientContext context = tryGetCurrentContext();
+        if (null == context) {
+            context = initializeAmbientContext(null);
+        }
+        return context;
+    }
+
+    public static void removeAmbientContext() {
+        callContext.remove();
+    }
+
+    /**
+     * initialize ambient context.
+     */
+    public static AmbientContext initializeAmbientContext(AmbientContext rawContext) {
+        AmbientContext context = (rawContext != null) ? rawContext : new AmbientContext();
+        callContext.set(context);
+        return context;
+    }
+
+    public static AmbientContext tryGetCurrentContext() {
+        return callContext.get();
+    }
+
+    /**
+     * create branch.
+     */
+    public AmbientContext createBranch() {
+        String branchId = generateNextCorrelationId();
+        AmbientContext branchContext = new AmbientContext(this);
+        branchContext.id = branchId;
+        return branchContext;
+    }
+
+    private String generateNextCorrelationId() {
+        return String.format("%s.%s", id, count.incrementAndGet());
+    }
+}

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaDebugServer.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaDebugServer.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 
 import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.adapter.ProtocolServer;
+import com.microsoft.java.debug.core.trace.AmbientContext;
 
 public class JavaDebugServer implements IDebugServer {
     private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
@@ -31,6 +32,7 @@ public class JavaDebugServer implements IDebugServer {
     private ServerSocket serverSocket = null;
     private boolean isStarted = false;
     private ExecutorService executor = null;
+    private AmbientContext context = AmbientContext.currentContext();
 
     private JavaDebugServer() {
         try {
@@ -130,6 +132,9 @@ public class JavaDebugServer implements IDebugServer {
             @Override
             public void run() {
                 try {
+                    // assign new AmbientContext for recycled thread.
+                    AmbientContext.removeAmbientContext();
+                    AmbientContext.initializeAmbientContext(context.createBranch());
                     ProtocolServer protocolServer = new ProtocolServer(connection.getInputStream(), connection.getOutputStream(),
                             JdtProviderContextFactory.createProviderContext());
                     // protocol server will dispatch request and send response in a while-loop.

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaDebugServer.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaDebugServer.java
@@ -21,9 +21,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.microsoft.AmbientContext;
 import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.adapter.ProtocolServer;
-import com.microsoft.java.debug.core.trace.AmbientContext;
 
 public class JavaDebugServer implements IDebugServer {
     private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);


### PR DESCRIPTION
- Add `AmbientContext` class, using InheritableThreadLocal to store context data including correlationId

- CorrelationId format: `[GUID of VSCode client/window].[Sequence # of debug session]`, e.g. `825b242b-7a73-4f5f-bcda-ab6eee88e28d.6` means the user's 6th launch of debug session in current window.

By doing this, we now know relation of these debug sessions.

![image](https://user-images.githubusercontent.com/2351748/33308363-1d75442a-d455-11e7-945b-b978627a0a89.png)
