### PR TITLE
Fix bug 183: No need to create exception request when no exception breakpoints are requested

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
@@ -91,9 +91,12 @@ public class DebugSession implements IDebugSession {
         EventRequestManager manager = vm.eventRequestManager();
         ArrayList<ExceptionRequest> legacy = new ArrayList<>(manager.exceptionRequests());
         manager.deleteEventRequests(legacy);
-        ExceptionRequest request = manager.createExceptionRequest(null, notifyCaught, notifyUncaught);
-        request.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
-        request.enable();
+        // When no exception breakpoints are requested, no need to create an empty exception request.
+        if (notifyCaught || notifyUncaught) {
+            ExceptionRequest request = manager.createExceptionRequest(null, notifyCaught, notifyUncaught);
+            request.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
+            request.enable();
+        }
     }
 
     @Override


### PR DESCRIPTION
fix bug https://github.com/Microsoft/vscode-java-debug/issues/183

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>