### PR TITLE
mitigate the deadlock issue between dispatchRequest and runInTerminalRequest

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProtocolServer.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProtocolServer.java
@@ -108,6 +108,6 @@ public class ProtocolServer extends AbstractProtocolServer {
                     ex.getMessage() != null ? ex.getMessage() : ex.toString()));
             }
             return null;
-        }).join();
+        });
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -70,39 +69,39 @@ public class EvaluateRequestHandler implements IDebugRequestHandler {
                     "Failed to evaluate. Reason: Cannot evaluate because the thread is resumed.");
         }
 
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                IEvaluationProvider engine = context.getProvider(IEvaluationProvider.class);
-                Value value = engine.evaluate(expression, stackFrameReference.getThread(), stackFrameReference.getDepth()).get();
-                IVariableFormatter variableFormatter = context.getVariableFormatter();
-                if (value instanceof VoidValue) {
-                    response.body = new Responses.EvaluateResponseBody(value.toString(), 0, "<void>", 0);
-                    return response;
-                }
-                long threadId = stackFrameReference.getThread().uniqueID();
-                if (value instanceof ObjectReference) {
-                    VariableProxy varProxy = new VariableProxy(stackFrameReference.getThread(), "eval", value);
-                    int referenceId = VariableUtils.hasChildren(value, showStaticVariables)
-                            ? context.getRecyclableIdPool().addObject(threadId, varProxy) : 0;
-                    int indexedVariableId = value instanceof ArrayReference ? ((ArrayReference) value).length() : 0;
-                    response.body = new Responses.EvaluateResponseBody(variableFormatter.valueToString(value, options),
-                            referenceId, variableFormatter.typeToString(value == null ? null : value.type(), options),
-                            indexedVariableId);
-                    return response;
-                }
-                // for primitive value
-                response.body = new Responses.EvaluateResponseBody(variableFormatter.valueToString(value, options), 0,
-                        variableFormatter.typeToString(value == null ? null : value.type(), options), 0);
-                return response;
-            } catch (InterruptedException | ExecutionException e) {
-                Throwable cause = e;
-                if (e instanceof ExecutionException && e.getCause() != null) {
-                    cause = e.getCause();
-                }
-                // TODO: distinguish user error of wrong expression(eg: compilation error)
-                logger.log(Level.WARNING, String.format("Cannot evalution expression because of %s.", cause.toString()), cause);
-                throw new CompletionException(cause);
+        try {
+            IEvaluationProvider engine = context.getProvider(IEvaluationProvider.class);
+            Value value = engine.evaluate(expression, stackFrameReference.getThread(), stackFrameReference.getDepth()).get();
+            IVariableFormatter variableFormatter = context.getVariableFormatter();
+            if (value instanceof VoidValue) {
+                response.body = new Responses.EvaluateResponseBody(value.toString(), 0, "<void>", 0);
+                return CompletableFuture.completedFuture(response);
             }
-        });
+            long threadId = stackFrameReference.getThread().uniqueID();
+            if (value instanceof ObjectReference) {
+                VariableProxy varProxy = new VariableProxy(stackFrameReference.getThread(), "eval", value);
+                int referenceId = VariableUtils.hasChildren(value, showStaticVariables)
+                        ? context.getRecyclableIdPool().addObject(threadId, varProxy) : 0;
+                int indexedVariableId = value instanceof ArrayReference ? ((ArrayReference) value).length() : 0;
+                response.body = new Responses.EvaluateResponseBody(variableFormatter.valueToString(value, options),
+                        referenceId, variableFormatter.typeToString(value == null ? null : value.type(), options),
+                        indexedVariableId);
+                return CompletableFuture.completedFuture(response);
+            }
+            // for primitive value
+            response.body = new Responses.EvaluateResponseBody(variableFormatter.valueToString(value, options), 0,
+                    variableFormatter.typeToString(value == null ? null : value.type(), options), 0);
+            return CompletableFuture.completedFuture(response);
+        } catch (InterruptedException | ExecutionException e) {
+            Throwable cause = e;
+            if (e instanceof ExecutionException && e.getCause() != null) {
+                cause = e.getCause();
+            }
+            // TODO: distinguish user error of wrong expression(eg: compilation error)
+            logger.log(Level.WARNING, String.format("Cannot evalution expression because of %s.", cause.toString()), cause);
+            CompletableFuture<Response> future = new CompletableFuture<>();
+            future.completeExceptionally(cause);
+            return future;
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

fix the blocking bug https://github.com/Microsoft/vscode-java-debug/issues/208

Previously, only evaluateRequestHandler return asyncFuture. So if i remove the async future from evaluate handler, no need to add join at dispatchRequest method.