### PR TITLE
Fix general exception for native methods.

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/StackFrameUtility.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/StackFrameUtility.java
@@ -14,6 +14,7 @@ package com.microsoft.java.debug.core;
 import com.sun.jdi.AbsentInformationException;
 import com.sun.jdi.IncompatibleThreadStateException;
 import com.sun.jdi.InvalidStackFrameException;
+import com.sun.jdi.NativeMethodException;
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.StackFrame;
 
@@ -32,8 +33,14 @@ public final class StackFrameUtility {
     public static void pop(StackFrame frame) throws DebugException {
         try {
             frame.thread().popFrames(frame);
-        } catch (IncompatibleThreadStateException | InvalidStackFrameException e) {
-            throw new DebugException(e.getMessage(), e);
+        } catch (IncompatibleThreadStateException e) {
+            throw new DebugException(String.format("%s occurred popping stack frame.", e.getMessage()), e);
+        } catch (InvalidStackFrameException e) {
+            throw new DebugException("Cannot pop up the top stack farme.", e);
+        } catch (NativeMethodException e) {
+            throw new DebugException("Cannot pop up the stack frame because it is not valid for a native method.", e);
+        } catch (RuntimeException e) {
+            throw new DebugException(String.format("Runtime exception happened: %s", e.getMessage()), e);
         }
     }
 


### PR DESCRIPTION
@akaroml @testforstephen @andxu 

For spring case, it will try to pop stack above native methods but it will failed. It is the design behavior of JVM and similar behavior in eclipse. 
However, the exception is https://docs.oracle.com/javase/7/docs/jdk/api/jpda/jdi/com/sun/jdi/InternalException.html instead of more specific https://docs.oracle.com/javase/7/docs/jdk/api/jpda/jdi/com/sun/jdi/NativeMethodException.html, just try the general runtime exception as eclipse did. 

We need document the non support scenarios here. 