### PR TITLE
fix the invalid stack exception during evaluation.

### DIFF
--- a/check_style.xml
+++ b/check_style.xml
@@ -104,9 +104,6 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="120"/>
-        </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
             <property name="tokens"

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/eval/JdtEvaluationProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/eval/JdtEvaluationProvider.java
@@ -95,7 +95,7 @@ public class JdtEvaluationProvider implements IEvaluationProvider {
         try  {
             ensureDebugTarget(thread.virtualMachine(), thread, 0);
             JDIThread jdiThread = getMockJDIThread(thread);
-            JDIStackFrame stackframe = (JDIStackFrame) jdiThread.getTopStackFrame();
+            JDIStackFrame stackframe = new JDIStackFrame(jdiThread, thread.frame(0), 0);
 
             ASTEvaluationEngine engine = new ASTEvaluationEngine(project, debugTarget);
             ICompiledExpression ie = (ICompiledExpression) breakpointExpressionMap


### PR DESCRIPTION
1, the LeftCurly rule has been deprecated.
2. fix the invalid stack exception during evaluation.