### PR TITLE
Fix the bug: Chinese characters directory will cause messy code during stack trace's source looking up

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
@@ -231,7 +231,8 @@ public class JdtSourceLookUpProvider implements ISourceLookUpProvider {
     private static String getFileURI(IResource resource) {
         URI uri = resource.getLocationURI();
         if (uri != null) {
-            String uriString = uri.toString();
+            // If the file path contains non ASCII characters, encode the result.
+            String uriString = uri.toASCIIString();
             // Fix uris by adding missing // to single file:/ prefix.
             return uriString.replaceFirst("file:/([^/])", "file:///$1");
         }


### PR DESCRIPTION
Fix bug https://github.com/Microsoft/vscode-java-debug/issues/273