### PR TITLE
Add script to push p2 artifact

### DIFF
--- a/com.microsoft.java.debug.repository/pushToBintray.sh
+++ b/com.microsoft.java.debug.repository/pushToBintray.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#Usage: ./pushToBintray.sh username apikey repo package
+BINTRAY_USER=$1
+BINTRAY_API_KEY=$2
+BINTRAY_REPO=$3
+PCK_NAME=$4
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+cd $SCRIPTPATH/..
+echo "Resolving the package version..."
+PCK_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+echo "The package version: $PCK_VERSION"
+
+function main() {
+    cd $SCRIPTPATH/target/repository
+
+    METADATA=./*
+    PLUGINDIR=plugins/*
+
+    echo "Processing p2 metadata file..."
+    for f in $METADATA;
+        do
+            if [ ! -d $f ]; then
+                echo "Pushing metadata file $f ..."
+                filename=$(basename "$f")
+                curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/$f;publish=0
+                curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/$filename;publish=0
+                echo ""
+            fi
+        done
+
+    echo "Processing plugins file..."
+    for f in $PLUGINDIR;
+        do
+            echo "Pushing plugin file $f ..."
+            curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/$f;publish=0;override=1
+            curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/${PCK_NAME}/${PCK_VERSION}/$f;publish=0
+            echo ""
+        done
+
+    echo "Publishing the new version"
+    curl -X POST -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/publish -d "{ \"discard\": \"false\" }"
+    curl -X POST -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/publish -d "{ \"discard\": \"false\" }"
+}
+
+main "$@"


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

I didn't find any existing jenkins plugin to deploy to bintray, so add a script to push the p2 artifacts to bintray.

The index page https://dl.bintray.com/vscjavaci/javadebug/ will show the latest version:
![image](https://user-images.githubusercontent.com/14052197/43374537-bf222a70-93e2-11e8-9754-3796e02366a2.png)

The sub path https://dl.bintray.com/vscjavaci/javadebug/releases will list the history:
![image](https://user-images.githubusercontent.com/14052197/43374642-49a3737a-93e3-11e8-874b-b817ebb867bc.png)
