### PR TITLE
Pass the pom version via the cli args

### DIFF
--- a/com.microsoft.java.debug.repository/pushToBintray.sh
+++ b/com.microsoft.java.debug.repository/pushToBintray.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
-#Usage: ./pushToBintray.sh username apikey repo package
+#Usage: ./pushToBintray.sh username apikey repo package version
 BINTRAY_USER=$1
 BINTRAY_API_KEY=$2
 BINTRAY_REPO=$3
 PCK_NAME=$4
+PCK_VERSION=$5
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
-
-cd $SCRIPTPATH/..
-echo "Resolving the package version..."
-PCK_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-echo "The package version: $PCK_VERSION"
 
 function main() {
     cd $SCRIPTPATH/target/repository


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

The `mvn help:evaluate` command doesn't work at the Jenkins shell environment, choose to pass it via the external command line argument.