### PR TITLE
Disable unnecessary request handlers for noDebug mode.

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
@@ -48,14 +48,16 @@ public class DebugAdapter implements IDebugAdapter {
     private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     private IDebugAdapterContext debugContext = null;
-    private Map<Command, List<IDebugRequestHandler>> requestHandlers = null;
+    private Map<Command, List<IDebugRequestHandler>> requestHandlersForDebug = null;
+    private Map<Command, List<IDebugRequestHandler>> requestHandlersForRun = null;
 
     /**
      * Constructor.
      */
     public DebugAdapter(IProtocolServer server, IProviderContext providerContext) {
         this.debugContext = new DebugAdapterContext(server, providerContext);
-        requestHandlers = new HashMap<>();
+        requestHandlersForDebug = new HashMap<>();
+        requestHandlersForRun = new HashMap<>();
         initialize();
     }
 
@@ -73,7 +75,8 @@ public class DebugAdapter implements IDebugAdapter {
             // the operation is meaningless
             return CompletableFuture.completedFuture(response);
         }
-        List<IDebugRequestHandler> handlers = requestHandlers.get(command);
+        List<IDebugRequestHandler> handlers = this.debugContext.isDebugMode()
+                ? requestHandlersForDebug.get(command) : requestHandlersForRun.get(command);
         if (handlers != null && !handlers.isEmpty()) {
             CompletableFuture<Messages.Response> future = CompletableFuture.completedFuture(response);
             for (IDebugRequestHandler handler : handlers) {
@@ -92,11 +95,11 @@ public class DebugAdapter implements IDebugAdapter {
     private void initialize() {
         // Register request handlers.
         // When there are multiple handlers registered for the same request, follow the rule "first register, first execute".
-        registerHandler(new InitializeRequestHandler());
-        registerHandler(new LaunchRequestHandler());
+        registerHandler(new InitializeRequestHandler(), true, true);
+        registerHandler(new LaunchRequestHandler(), true, true);
         registerHandler(new AttachRequestHandler());
-        registerHandler(new ConfigurationDoneRequestHandler());
-        registerHandler(new DisconnectRequestHandler());
+        registerHandler(new ConfigurationDoneRequestHandler(), true, true);
+        registerHandler(new DisconnectRequestHandler(), true, true);
         registerHandler(new SetBreakpointsRequestHandler());
         registerHandler(new SetExceptionBreakpointsRequestHandler());
         registerHandler(new SourceRequestHandler());
@@ -113,6 +116,19 @@ public class DebugAdapter implements IDebugAdapter {
     }
 
     private void registerHandler(IDebugRequestHandler handler) {
+        registerHandler(handler, true, false);
+    }
+
+    private void registerHandler(IDebugRequestHandler handler, boolean forDebug, boolean forRun) {
+        if (forDebug) {
+            registerHandler(requestHandlersForDebug, handler);
+        }
+        if (forRun) {
+            registerHandler(requestHandlersForRun, handler);
+        }
+    }
+
+    private void registerHandler(Map<Command, List<IDebugRequestHandler>> requestHandlers, IDebugRequestHandler handler) {
         for (Command command : handler.getTargetCommands()) {
             List<IDebugRequestHandler> handlerList = requestHandlers.get(command);
             if (handlerList == null) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
@@ -38,6 +38,7 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     private Charset debuggeeEncoding;
     private transient boolean vmTerminated;
     private boolean isVmStopOnEntry = false;
+    private boolean isDebugMode = true;
     private String mainClass;
     private StepFilters stepFilters;
 
@@ -230,5 +231,15 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     @Override
     public IStackFrameManager getStackFrameManager() {
         return stackFrameManager;
+    }
+
+    @Override
+    public boolean isDebugMode() {
+        return this.isDebugMode;
+    }
+
+    @Override
+    public void setDebugMode(boolean isDebugMode) {
+        this.isDebugMode = isDebugMode;
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
@@ -101,4 +101,8 @@ public interface IDebugAdapterContext {
     StepFilters getStepFilters();
 
     IStackFrameManager getStackFrameManager();
+
+    boolean isDebugMode();
+
+    void setDebugMode(boolean isDebugMode);
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -86,6 +86,7 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
         context.setAttached(false);
         context.setSourcePaths(launchArguments.sourcePaths);
         context.setVmStopOnEntry(launchArguments.stopOnEntry);
+        context.setDebugMode(!launchArguments.noDebug);
         context.setMainClass(parseMainClassWithoutModuleName(launchArguments.mainClass));
         context.setStepFilters(launchArguments.stepFilters);
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
@@ -70,6 +70,7 @@ public class Requests {
         public String cwd;
         public Map<String, String> env;
         public boolean stopOnEntry;
+        public boolean noDebug = false;
         public CONSOLE console = CONSOLE.internalConsole;
     }
 


### PR DESCRIPTION
For debug mode, enable all the request handlers. For noDebug mode, only enable handlers for initialize, configurationDone, launch, disconnect requests.

Ref:
https://github.com/Microsoft/vscode-java-debug/issues/351#issuecomment-412730985
