### PR TITLE
Fix: correctly return contructed envrionment variables.

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -164,7 +164,7 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
                 envVars[i++] = entry.getKey() + "=" + entry.getValue();
             }
         }
-        return null;
+        return envVars;
     }
 
     /**


### PR DESCRIPTION
Previously the constructed `envVars` are mistakenly not returned. 

See https://github.com/Microsoft/vscode-java-debug/issues/393