### PR TITLE
Fix variable perf issue & logical structure doesn't work with JDK 11

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructure.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructure.java
@@ -14,8 +14,6 @@ package com.microsoft.java.debug.core.adapter.variables;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.sun.jdi.ClassType;
 import com.sun.jdi.InterfaceType;
 import com.sun.jdi.ObjectReference;
@@ -23,21 +21,21 @@ import com.sun.jdi.Type;
 
 public class JavaLogicalStructure {
     private final String type;
-    private final String value;
-    private final String size;
+    private final Expression value;
+    private final Expression size;
     private final LogicalVariable[] variables;
 
     /**
      * Constructor.
      */
-    public JavaLogicalStructure(String type, String value, String size, LogicalVariable[] variables) {
+    public JavaLogicalStructure(String type, Expression value, Expression size, LogicalVariable[] variables) {
         this.value = value;
         this.type = type;
         this.size = size;
         this.variables = variables;
     }
 
-    public String getValue() {
+    public Expression getValue() {
         return value;
     }
 
@@ -45,7 +43,7 @@ public class JavaLogicalStructure {
         return type;
     }
 
-    public String getSize() {
+    public Expression getSize() {
         return size;
     }
 
@@ -82,14 +80,14 @@ public class JavaLogicalStructure {
     }
 
     public boolean isIndexedVariable() {
-        return StringUtils.isNotBlank(size);
+        return size != null;
     }
 
     public static class LogicalVariable {
         private final String name;
-        private final String value;
+        private final Expression value;
 
-        public LogicalVariable(String name, String value) {
+        public LogicalVariable(String name, Expression value) {
             this.name = name;
             this.value = value;
         }
@@ -98,8 +96,26 @@ public class JavaLogicalStructure {
             return name;
         }
 
-        public String getValue() {
+        public Expression getValue() {
             return value;
         }
+    }
+
+    public static class Expression {
+        public ExpressionType type;
+        public String value;
+
+        /**
+         *  Constructor.
+         */
+        public Expression(ExpressionType type, String value) {
+            super();
+            this.type = type;
+            this.value = value;
+        }
+    }
+
+    public static enum ExpressionType {
+        FIELD, METHOD, EXPRESSION
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructure.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructure.java
@@ -11,40 +11,52 @@
 
 package com.microsoft.java.debug.core.adapter.variables;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 
+import com.microsoft.java.debug.core.adapter.IEvaluationProvider;
+import com.sun.jdi.ClassNotLoadedException;
 import com.sun.jdi.ClassType;
+import com.sun.jdi.Field;
+import com.sun.jdi.IncompatibleThreadStateException;
 import com.sun.jdi.InterfaceType;
+import com.sun.jdi.InvalidTypeException;
+import com.sun.jdi.InvocationException;
+import com.sun.jdi.Method;
 import com.sun.jdi.ObjectReference;
+import com.sun.jdi.ThreadReference;
 import com.sun.jdi.Type;
+import com.sun.jdi.Value;
 
 public class JavaLogicalStructure {
     private final String type;
-    private final LogicalStructureExpression value;
-    private final LogicalStructureExpression size;
+    private final LogicalStructureExpression valueExpression;
+    private final LogicalStructureExpression sizeExpression;
     private final LogicalVariable[] variables;
 
     /**
      * Constructor.
      */
-    public JavaLogicalStructure(String type, LogicalStructureExpression value, LogicalStructureExpression size, LogicalVariable[] variables) {
-        this.value = value;
+    public JavaLogicalStructure(String type, LogicalStructureExpression valueExpression, LogicalStructureExpression sizeExpression,
+            LogicalVariable[] variables) {
+        this.valueExpression = valueExpression;
         this.type = type;
-        this.size = size;
+        this.sizeExpression = sizeExpression;
         this.variables = variables;
-    }
-
-    public LogicalStructureExpression getValue() {
-        return value;
     }
 
     public String getType() {
         return type;
     }
 
-    public LogicalStructureExpression getSize() {
-        return size;
+    public LogicalStructureExpression getValueExpression() {
+        return valueExpression;
+    }
+
+    public LogicalStructureExpression getSizeExpression() {
+        return sizeExpression;
     }
 
     public LogicalVariable[] getVariables() {
@@ -79,25 +91,93 @@ public class JavaLogicalStructure {
         return false;
     }
 
-    public boolean isIndexedVariable() {
-        return size != null;
+    /**
+     * Return the logical size of the specified thisObject.
+     */
+    public Value getSize(ObjectReference thisObject, ThreadReference thread, IEvaluationProvider evaluationEngine)
+            throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException, InvocationException,
+            InterruptedException, ExecutionException, UnsupportedOperationException {
+        if (sizeExpression  == null) {
+            throw new UnsupportedOperationException("The object hasn't defined the logical size operation.");
+        }
+
+        return getValue(thisObject, sizeExpression, thread, evaluationEngine);
+    }
+
+    /**
+     * Return the logical value of the specified thisObject.
+     */
+    public Value getValue(ObjectReference thisObject, ThreadReference thread, IEvaluationProvider evaluationEngine)
+            throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException, InvocationException,
+            InterruptedException, ExecutionException {
+        return getValue(thisObject, valueExpression, thread, evaluationEngine);
+    }
+
+    private static Value getValue(ObjectReference thisObject, LogicalStructureExpression expression, ThreadReference thread,
+            IEvaluationProvider evaluationEngine)
+            throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException, InvocationException,
+            InterruptedException, ExecutionException {
+        if (expression.type == LogicalStructureExpressionType.METHOD) {
+            return getValueByMethod(thisObject, expression.value, thread);
+        } else if (expression.type == LogicalStructureExpressionType.FIELD) {
+            return getValueByField(thisObject, expression.value, thread);
+        } else {
+            return evaluationEngine.evaluate(expression.value, thisObject, thread).get();
+        }
+    }
+
+    private static Value getValueByMethod(ObjectReference thisObject, String methodName, ThreadReference thread)
+            throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException, InvocationException {
+        List<Method> methods = thisObject.referenceType().allMethods();
+        Method targetMethod = null;
+        for (Method method : methods) {
+            if (Objects.equals(method.name(), methodName) && method.argumentTypeNames().isEmpty()) {
+                targetMethod = method;
+                break;
+            }
+        }
+
+        if (targetMethod == null) {
+            return null;
+        }
+
+        return thisObject.invokeMethod(thread, targetMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+    }
+
+    private static Value getValueByField(ObjectReference thisObject, String filedName, ThreadReference thread) {
+        List<Field> fields = thisObject.referenceType().allFields();
+        Field targetField = null;
+        for (Field field : fields) {
+            if (Objects.equals(field.name(), filedName)) {
+                targetField = field;
+                break;
+            }
+        }
+
+        if (targetField == null) {
+            return null;
+        }
+
+        return thisObject.getValue(targetField);
     }
 
     public static class LogicalVariable {
         private final String name;
-        private final LogicalStructureExpression value;
+        private final LogicalStructureExpression valueExpression;
 
-        public LogicalVariable(String name, LogicalStructureExpression value) {
+        public LogicalVariable(String name, LogicalStructureExpression valueExpression) {
             this.name = name;
-            this.value = value;
+            this.valueExpression = valueExpression;
         }
 
         public String getName() {
             return name;
         }
 
-        public LogicalStructureExpression getValue() {
-            return value;
+        public Value getValue(ObjectReference thisObject, ThreadReference thread, IEvaluationProvider evaluationEngine)
+                throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException, InvocationException,
+                InterruptedException, ExecutionException {
+            return JavaLogicalStructure.getValue(thisObject, valueExpression, thread, evaluationEngine);
         }
     }
 
@@ -109,7 +189,6 @@ public class JavaLogicalStructure {
          *  Constructor.
          */
         public LogicalStructureExpression(LogicalStructureExpressionType type, String value) {
-            super();
             this.type = type;
             this.value = value;
         }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructure.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructure.java
@@ -21,21 +21,21 @@ import com.sun.jdi.Type;
 
 public class JavaLogicalStructure {
     private final String type;
-    private final Expression value;
-    private final Expression size;
+    private final LogicalStructureExpression value;
+    private final LogicalStructureExpression size;
     private final LogicalVariable[] variables;
 
     /**
      * Constructor.
      */
-    public JavaLogicalStructure(String type, Expression value, Expression size, LogicalVariable[] variables) {
+    public JavaLogicalStructure(String type, LogicalStructureExpression value, LogicalStructureExpression size, LogicalVariable[] variables) {
         this.value = value;
         this.type = type;
         this.size = size;
         this.variables = variables;
     }
 
-    public Expression getValue() {
+    public LogicalStructureExpression getValue() {
         return value;
     }
 
@@ -43,7 +43,7 @@ public class JavaLogicalStructure {
         return type;
     }
 
-    public Expression getSize() {
+    public LogicalStructureExpression getSize() {
         return size;
     }
 
@@ -85,9 +85,9 @@ public class JavaLogicalStructure {
 
     public static class LogicalVariable {
         private final String name;
-        private final Expression value;
+        private final LogicalStructureExpression value;
 
-        public LogicalVariable(String name, Expression value) {
+        public LogicalVariable(String name, LogicalStructureExpression value) {
             this.name = name;
             this.value = value;
         }
@@ -96,26 +96,26 @@ public class JavaLogicalStructure {
             return name;
         }
 
-        public Expression getValue() {
+        public LogicalStructureExpression getValue() {
             return value;
         }
     }
 
-    public static class Expression {
-        public ExpressionType type;
+    public static class LogicalStructureExpression {
+        public LogicalStructureExpressionType type;
         public String value;
 
         /**
          *  Constructor.
          */
-        public Expression(ExpressionType type, String value) {
+        public LogicalStructureExpression(LogicalStructureExpressionType type, String value) {
             super();
             this.type = type;
             this.value = value;
         }
     }
 
-    public static enum ExpressionType {
-        FIELD, METHOD, EXPRESSION
+    public static enum LogicalStructureExpressionType {
+        FIELD, METHOD, EVALUATION_SNIPPET
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructureManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructureManager.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.Expression;
+import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.ExpressionType;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalVariable;
 import com.sun.jdi.ObjectReference;
 
@@ -22,12 +24,18 @@ public class JavaLogicalStructureManager {
     private static final List<JavaLogicalStructure> supportedLogicalStructures = Collections.synchronizedList(new ArrayList<>());
 
     static {
-        supportedLogicalStructures.add(new JavaLogicalStructure("java.util.Map", "return entrySet().toArray();", "return size();", new LogicalVariable[0]));
+        supportedLogicalStructures.add(new JavaLogicalStructure("java.util.Map",
+                new Expression(ExpressionType.METHOD, "entrySet"),
+                new Expression(ExpressionType.METHOD, "size"),
+                new LogicalVariable[0]));
         supportedLogicalStructures.add(new JavaLogicalStructure("java.util.Map$Entry", null, null, new LogicalVariable[] {
-            new LogicalVariable("key", "return getKey();"),
-            new LogicalVariable("value", "return getValue();")
+            new LogicalVariable("key", new Expression(ExpressionType.METHOD, "getKey")),
+            new LogicalVariable("value", new Expression(ExpressionType.METHOD, "getValue"))
         }));
-        supportedLogicalStructures.add(new JavaLogicalStructure("java.util.Collection", "return toArray();", "return size();", new LogicalVariable[0]));
+        supportedLogicalStructures.add(new JavaLogicalStructure("java.util.Collection",
+                new Expression(ExpressionType.METHOD, "toArray"),
+                new Expression(ExpressionType.METHOD, "size"),
+                new LogicalVariable[0]));
     }
 
     /**
@@ -48,7 +56,7 @@ public class JavaLogicalStructureManager {
         return structure != null && structure.isIndexedVariable();
     }
 
-    public static String getLogicalSize(ObjectReference obj) {
+    public static Expression getLogicalSize(ObjectReference obj) {
         JavaLogicalStructure structure = getLogicalStructure(obj);
         return structure == null ? null : structure.getSize();
     }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructureManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructureManager.java
@@ -15,8 +15,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.Expression;
-import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.ExpressionType;
+import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalStructureExpression;
+import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalStructureExpressionType;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalVariable;
 import com.sun.jdi.ObjectReference;
 
@@ -25,16 +25,16 @@ public class JavaLogicalStructureManager {
 
     static {
         supportedLogicalStructures.add(new JavaLogicalStructure("java.util.Map",
-                new Expression(ExpressionType.METHOD, "entrySet"),
-                new Expression(ExpressionType.METHOD, "size"),
+                new LogicalStructureExpression(LogicalStructureExpressionType.METHOD, "entrySet"),
+                new LogicalStructureExpression(LogicalStructureExpressionType.METHOD, "size"),
                 new LogicalVariable[0]));
         supportedLogicalStructures.add(new JavaLogicalStructure("java.util.Map$Entry", null, null, new LogicalVariable[] {
-            new LogicalVariable("key", new Expression(ExpressionType.METHOD, "getKey")),
-            new LogicalVariable("value", new Expression(ExpressionType.METHOD, "getValue"))
+            new LogicalVariable("key", new LogicalStructureExpression(LogicalStructureExpressionType.METHOD, "getKey")),
+            new LogicalVariable("value", new LogicalStructureExpression(LogicalStructureExpressionType.METHOD, "getValue"))
         }));
         supportedLogicalStructures.add(new JavaLogicalStructure("java.util.Collection",
-                new Expression(ExpressionType.METHOD, "toArray"),
-                new Expression(ExpressionType.METHOD, "size"),
+                new LogicalStructureExpression(LogicalStructureExpressionType.METHOD, "toArray"),
+                new LogicalStructureExpression(LogicalStructureExpressionType.METHOD, "size"),
                 new LogicalVariable[0]));
     }
 
@@ -56,7 +56,7 @@ public class JavaLogicalStructureManager {
         return structure != null && structure.isIndexedVariable();
     }
 
-    public static Expression getLogicalSize(ObjectReference obj) {
+    public static LogicalStructureExpression getLogicalSize(ObjectReference obj) {
         JavaLogicalStructure structure = getLogicalStructure(obj);
         return structure == null ? null : structure.getSize();
     }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructureManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/JavaLogicalStructureManager.java
@@ -14,11 +14,19 @@ package com.microsoft.java.debug.core.adapter.variables;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
+import com.microsoft.java.debug.core.adapter.IEvaluationProvider;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalStructureExpression;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalStructureExpressionType;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalVariable;
+import com.sun.jdi.ClassNotLoadedException;
+import com.sun.jdi.IncompatibleThreadStateException;
+import com.sun.jdi.InvalidTypeException;
+import com.sun.jdi.InvocationException;
 import com.sun.jdi.ObjectReference;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.Value;
 
 public class JavaLogicalStructureManager {
     private static final List<JavaLogicalStructure> supportedLogicalStructures = Collections.synchronizedList(new ArrayList<>());
@@ -51,13 +59,25 @@ public class JavaLogicalStructureManager {
         return null;
     }
 
+    /**
+     * Return true if the specified Object has defined the logical size.
+     */
     public static boolean isIndexedVariable(ObjectReference obj) {
         JavaLogicalStructure structure = getLogicalStructure(obj);
-        return structure != null && structure.isIndexedVariable();
+        return structure != null && structure.getSizeExpression() != null;
     }
 
-    public static LogicalStructureExpression getLogicalSize(ObjectReference obj) {
-        JavaLogicalStructure structure = getLogicalStructure(obj);
-        return structure == null ? null : structure.getSize();
+    /**
+     * Return the logical size if the specified Object has defined the logical size.
+     */
+    public static Value getLogicalSize(ObjectReference thisObject, ThreadReference thread, IEvaluationProvider evaluationEngine)
+            throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException, InvocationException,
+            InterruptedException, ExecutionException, UnsupportedOperationException {
+        JavaLogicalStructure structure = getLogicalStructure(thisObject);
+        if (structure == null) {
+            return null;
+        }
+
+        return structure.getSize(thisObject, thread, evaluationEngine);
     }
 }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

fixes Microsoft/vscode-java-debug#571
fixes Microsoft/vscode-java-debug#568

Use the evaluation engine to resolve the logical structure, it has perf issue. On the other hand, in JDK 11, jdt has an issue on parsing the compiled expression `return entrySet();` for Map. See jdt issue https://bugs.eclipse.org/bugs/show_bug.cgi?id=543604.

The PR will get the logical structure via the JDI approach. It will fix perf issue and JDK 11 problem. 