### PR TITLE
Fix bug: the debug toolbar doesn't close after the program running in terminal has exited

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -224,6 +224,7 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
 
         if (context.supportsRunInTerminalRequest()
                 && (launchArguments.console == CONSOLE.integratedTerminal || launchArguments.console == CONSOLE.externalTerminal)) {
+            waitForDebuggeeConsole.complete(true);
             return activeLaunchHandler.launchInTerminal(launchArguments, response, context);
         }
 


### PR DESCRIPTION
Fixes Microsoft/vscode-java-debug#582

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>