### PR TITLE
Break out of the while loop for better performance

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
@@ -81,6 +81,8 @@ public abstract class AbstractDisconnectRequestHandler implements IDebugRequestH
                     Files.deleteIfExists(context.getArgsfile());
                     context.setArgsfile(null);
                 }
+
+                break;
             } catch (IOException e) {
                 // do nothing.
                 logger.log(Level.WARNING, "Failed to destory launch files, will retry again.");


### PR DESCRIPTION
Now it will cost about 5 seconds in the destroyLaunchFiles function,
there should have a break statement if no IOException is caught
in each loop iteration for better performance.

Signed-off-by: tom-shan <s00347147@163.com>