### PR TITLE
skip cleanup when attached to the process

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
@@ -56,7 +56,7 @@ public abstract class AbstractDisconnectRequestHandler implements IDebugRequestH
     }
 
     private boolean shouldDestroyLaunchFiles(IDebugAdapterContext context) {
-        if(context.isAttached()){
+        if (context.isAttached()) {
             return false; // the debugger is not an owner of the process, so the cleanup can be ignored.
         }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
@@ -56,6 +56,10 @@ public abstract class AbstractDisconnectRequestHandler implements IDebugRequestH
     }
 
     private boolean shouldDestroyLaunchFiles(IDebugAdapterContext context) {
+        if(context.isAttached()){
+            return false; // the debugger is not an owner of the process, so the cleanup can be ignored.
+        }
+
         // Delete the temporary launch files must happen after the debuggee process is fully exited,
         // otherwise it throws error saying the file is being used by other process.
         // In Debug mode, the debugger is able to receive VM terminate event. It's sensible to do cleanup.


### PR DESCRIPTION
Currently, the Debug Adapter, after attaching to the process and receiving a `disconnect` request, performs  a blocking cleanup operation. 

This operation blocks for 5 seconds to do a `launch` related cleanup, so it makes sense to skip it in the case of an attached Debug Adapter.

