### PR TITLE
Support to use a launcher to run in terminal

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -184,8 +184,10 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
      */
     public static String[] constructLaunchCommands(LaunchArguments launchArguments, boolean serverMode, String address) {
         String slash = System.getProperty("file.separator");
-
         List<String> launchCmds = new ArrayList<>();
+        if (launchArguments.launcherScript != null) {
+            launchCmds.add(launchArguments.launcherScript);
+        }
         final String javaHome = StringUtils.isNotEmpty(DebugSettings.getCurrent().javaHome) ? DebugSettings.getCurrent().javaHome
                 : System.getProperty("java.home");
         launchCmds.add(javaHome + slash + "bin" + slash + "java");

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
@@ -82,8 +82,9 @@ public class Requests {
         public Map<String, String> env;
         public boolean stopOnEntry;
         public boolean noDebug = false;
-        public CONSOLE console = CONSOLE.internalConsole;
+        public CONSOLE console = CONSOLE.integratedTerminal;
         public ShortenApproach shortenCommandLine = ShortenApproach.NONE;
+        public String launcherScript;
     }
 
     public static class AttachArguments extends LaunchBaseArguments {


### PR DESCRIPTION
Accept an optional `launcherScript` in launchArgs, and prepend it to launch cmds.