### PR TITLE
Add minor installation note in README.md about mvnw.cmd/mvnw

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ The Java Debug Server is the bridge between VSCode and JVM. The implementation i
 - com.microsoft.java.debug.core - the core logic of the debug server
 - com.microsoft.java.debug.plugin - wraps the debug server into an Eclipse plugin to work with Eclipse JDT Language Server
 
+## Installation
+
+### Windows:
+```
+mvnw.cmd clean install
+```
+### Linux and macOS:
+```
+./mvnw clean install
+```
+
 License
 -------
 EPL 1.0, See [LICENSE](LICENSE.txt) file.


### PR DESCRIPTION
Just an idea. Probably there's a better way to do this. But for those getting started with Java again (and not as familiar with maven wrapper script), it did take a minute to figure out what to do to get it installed (i.e., that `mvn clean install` doesn't work).