### PR TITLE
Use -m prefix only when the main class is contained in a module

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugUtility.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugUtility.java
@@ -148,7 +148,7 @@ public class DebugUtility {
 
         // For java 9 project, should specify "-m $MainClass".
         String[] mainClasses = mainClass.split("/");
-        if (StringUtils.isNotBlank(modulePaths) || mainClasses.length == 2) {
+        if (mainClasses.length == 2) {
             mainClass = "-m " + mainClass;
         }
         if (StringUtils.isNotBlank(programArguments)) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -207,7 +207,7 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
         }
         // For java 9 project, should specify "-m $MainClass".
         String[] mainClasses = launchArguments.mainClass.split("/");
-        if (ArrayUtils.isNotEmpty(launchArguments.modulePaths) || mainClasses.length == 2) {
+        if (mainClasses.length == 2) {
             launchCmds.add("-m");
         }
         launchCmds.add(launchArguments.mainClass);


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix #303