### PR TITLE
Added debugger user setting for setting numeric precision

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
@@ -22,6 +22,7 @@ public final class DebugSettings {
     private static DebugSettings current = new DebugSettings();
 
     public int maxStringLength = 0;
+    public int numericPrecision = 0;
     public boolean showStaticVariables = false;
     public boolean showQualifiedNames = false;
     public boolean showHex = false;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/VariableUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/VariableUtils.java
@@ -248,6 +248,10 @@ public abstract class VariableUtils {
         if (DebugSettings.getCurrent().maxStringLength > 0) {
             options.put(StringObjectFormatter.MAX_STRING_LENGTH_OPTION, DebugSettings.getCurrent().maxStringLength);
         }
+
+        if (DebugSettings.getCurrent().numericPrecision > 0) {
+            options.put(NumericFormatter.NUMERIC_PRECISION_OPTION, DebugSettings.getCurrent().numericPrecision);
+        }
     }
 
     private VariableUtils() {


### PR DESCRIPTION
Allows for fix for [microsoft/vscode-java-debug#745](https://github.com/microsoft/vscode-java-debug/issues/745#issue-547078106)