### PR TITLE
Up tycho version to 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <base.name>Java Debug Server for Visual Studio Code</base.name>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tycho-version>1.2.0</tycho-version>
+        <tycho-version>1.5.1</tycho-version>
         <checkstyleDir>${basedir}</checkstyleDir>
     </properties>
 


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

In JDK 13, build command will fail. Up tycho version to 1.5.1 to support the latest JDK.