### PR TITLE
Dedup the changed classes before hot reload

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaHotCodeReplaceProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaHotCodeReplaceProvider.java
@@ -298,7 +298,7 @@ public class JavaHotCodeReplaceProvider implements IHotCodeReplaceProvider, IRes
                                 && JdtUtils.isSameFile(deltaResources.get(j), resource)) {
                                 duplicate = true;
                                 break;
-                            } 
+                            }
                         }
 
                         if (!duplicate) {

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtUtils.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtUtils.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -398,5 +399,20 @@ public class JdtUtils {
             name.append("[]"); //$NON-NLS-1$
         }
         return name.toString();
+    }
+
+    /**
+     * Check whether two resources point to the same physical file.
+     */
+    public static boolean isSameFile(IResource resource1, IResource resource2) {
+        if (resource1 == null || resource2 == null) {
+            return false;
+        }
+
+        if (Objects.equals(resource1, resource2)) {
+            return true;
+        }
+
+        return Objects.equals(resource1.getLocation(), resource2.getLocation());
     }
 }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix microsoft/vscode-java-debug#855

Root cause:
Previously the extension uses Set to dedup the changed resources and classes. One exceptional case is for multiple module maven projects, the classes changed in sub module also appear in the resource change listener of the parent project. Use HastSet cannot dedup the resource object even though they are pointing to the same physical file. 