### PR TITLE
Fix Java exec exception 'UNC path is missing sharename'

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveJavaExecutableHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveJavaExecutableHandler.java
@@ -90,7 +90,9 @@ public class ResolveJavaExecutableHandler {
                 if (!isBin && j == 0) {
                     continue;
                 }
-                File javaFile = new File(vmInstallLocation, Paths.get(javaBinCandidates[j], javaExecCandidates[i]).toString());
+
+                String execRelativePath = j == 0 ? javaExecCandidates[i] : Paths.get(javaBinCandidates[j], javaExecCandidates[i]).toString();
+                File javaFile = new File(vmInstallLocation, execRelativePath);
                 if (javaFile.isFile()) {
                     return javaFile;
                 }


### PR DESCRIPTION
Fix microsoft/vscode-java-debug#882