### PR TITLE
Use the correct runtime to validate the JVM versions between the debugger and debuggee

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ISourceLookUpProvider.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ISourceLookUpProvider.java
@@ -30,4 +30,14 @@ public interface ISourceLookUpProvider extends IProvider {
     String getSourceFileURI(String fullyQualifiedName, String sourcePath);
 
     String getSourceContents(String uri);
+
+    /**
+     * Returns the Java runtime that the specified project's build path used.
+     * @param projectName
+     *                  the specified project name
+     * @return the Java runtime version the specified project used. null if projectName is empty or doesn't exist.
+     */
+    default String getJavaRuntimeVersion(String projectName) {
+        return null;
+    }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
@@ -40,6 +40,8 @@ import com.microsoft.java.debug.core.protocol.Requests.AttachArguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 import com.sun.jdi.connect.IllegalConnectorArgumentsException;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class AttachRequestHandler implements IDebugRequestHandler {
     private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private VMHandler vmHandler = new VMHandler();
@@ -59,28 +61,14 @@ public class AttachRequestHandler implements IDebugRequestHandler {
 
         IVirtualMachineManagerProvider vmProvider = context.getProvider(IVirtualMachineManagerProvider.class);
         vmHandler.setVmProvider(vmProvider);
-
+        IDebugSession debugSession = null;
         try {
             logger.info(String.format("Trying to attach to remote debuggee VM %s:%d .", attachArguments.hostName, attachArguments.port));
-            IDebugSession debugSession = DebugUtility.attach(vmProvider.getVirtualMachineManager(), attachArguments.hostName, attachArguments.port,
+            debugSession = DebugUtility.attach(vmProvider.getVirtualMachineManager(), attachArguments.hostName, attachArguments.port,
                     attachArguments.timeout);
             context.setDebugSession(debugSession);
             vmHandler.connectVirtualMachine(debugSession.getVM());
             logger.info("Attaching to debuggee VM succeeded.");
-
-            // If the debugger and debuggee run at the different JVM platforms, show a warning message.
-            if (debugSession != null) {
-                String debuggeeVersion = debugSession.getVM().version();
-                String debuggerVersion = System.getProperty("java.version");
-                if (!debuggerVersion.equals(debuggeeVersion)) {
-                    String warnMessage = String.format("[Warn] The debugger and the debuggee are running in different versions of JVMs. "
-                        + "You could see wrong source mapping results.\n"
-                        + "Debugger JVM version: %s\n"
-                        + "Debuggee JVM version: %s", debuggerVersion, debuggeeVersion);
-                    logger.warning(warnMessage);
-                    context.getProtocolServer().sendEvent(Events.OutputEvent.createConsoleOutput(warnMessage));
-                }
-            }
         } catch (IOException | IllegalConnectorArgumentsException e) {
             throw AdapterUtils.createCompletionException(
                 String.format("Failed to attach to remote debuggee VM. Reason: %s", e.toString()),
@@ -96,6 +84,20 @@ public class AttachRequestHandler implements IDebugRequestHandler {
         // TODO: Clean up the initialize mechanism
         ISourceLookUpProvider sourceProvider = context.getProvider(ISourceLookUpProvider.class);
         sourceProvider.initialize(context, options);
+        // If the debugger and debuggee run at the different JVM platforms, show a warning message.
+        if (debugSession != null) {
+            String debuggeeVersion = debugSession.getVM().version();
+            String debuggerVersion = sourceProvider.getJavaRuntimeVersion(attachArguments.projectName);
+            if (StringUtils.isNotBlank(debuggerVersion) && !debuggerVersion.equals(debuggeeVersion)) {
+                String warnMessage = String.format("[Warn] The debugger and the debuggee are running in different versions of JVMs. "
+                    + "You could see wrong source mapping results.\n"
+                    + "Debugger JVM version: %s\n"
+                    + "Debuggee JVM version: %s", debuggerVersion, debuggeeVersion);
+                logger.warning(warnMessage);
+                context.getProtocolServer().sendEvent(Events.OutputEvent.createConsoleOutput(warnMessage));
+            }
+        }
+
         IEvaluationProvider evaluationProvider = context.getProvider(IEvaluationProvider.class);
         evaluationProvider.initialize(context, options);
         IHotCodeReplaceProvider hcrProvider = context.getProvider(IHotCodeReplaceProvider.class);

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveJavaExecutableHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveJavaExecutableHandler.java
@@ -61,26 +61,33 @@ public class ResolveJavaExecutableHandler {
                 }
             }
 
-            if (targetProject == null) {
-                return null;
-            }
-
-            IVMInstall vmInstall = JavaRuntime.getVMInstall(targetProject);
-            if (vmInstall == null || vmInstall.getInstallLocation() == null) {
-                return null;
-            }
-
-            File exe = findJavaExecutable(vmInstall.getInstallLocation());
-            if (exe == null) {
-                return null;
-            }
-
-            return exe.getAbsolutePath();
+            return resolveJavaExecutable(targetProject);
         } catch (CoreException e) {
             logger.log(Level.SEVERE, "Failed to resolve java executable: " + e.getMessage(), e);
         }
 
         return null;
+    }
+
+    /**
+     * Resolve the Java executable path from the project's Java runtime.
+     */
+    public static String resolveJavaExecutable(IJavaProject javaProject) throws CoreException {
+        if (javaProject == null) {
+            return null;
+        }
+
+        IVMInstall vmInstall = JavaRuntime.getVMInstall(javaProject);
+        if (vmInstall == null || vmInstall.getInstallLocation() == null) {
+            return null;
+        }
+
+        File exe = findJavaExecutable(vmInstall.getInstallLocation());
+        if (exe == null) {
+            return null;
+        }
+
+        return exe.getAbsolutePath();
     }
 
     private static File findJavaExecutable(File vmInstallLocation) {

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveJavaExecutableHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveJavaExecutableHandler.java
@@ -12,7 +12,6 @@
 package com.microsoft.java.debug.plugin.internal;
 
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -98,8 +97,7 @@ public class ResolveJavaExecutableHandler {
                     continue;
                 }
 
-                String execRelativePath = j == 0 ? javaExecCandidates[i] : Paths.get(javaBinCandidates[j], javaExecCandidates[i]).toString();
-                File javaFile = new File(vmInstallLocation, execRelativePath);
+                File javaFile = new File(vmInstallLocation, javaBinCandidates[j] + javaExecCandidates[i]);
                 if (javaFile.isFile()) {
                     return javaFile;
                 }


### PR DESCRIPTION
When attaching to an existing debuggee program, its runtime version may be different with the one that the debugger used to build your project. Although the debugger still works when the JDK mismatches. But stepping into the JDK system library, the native library source line may be not consistent with the remote one and cause the line mismatch during stepping. For such case, the debugger will print a warning message when runtime is not matched in the DEBUG CONSOLE view.