### PR TITLE
Add quotes to the argfile argument if the argfile path contains space

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -130,7 +130,7 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
         } else if (launchArguments.shortenCommandLine == ShortenApproach.ARGFILE) {
             try {
                 Path tempfile = AdapterUtils.generateArgfile(launchArguments.classPaths, launchArguments.modulePaths);
-                launchArguments.vmArgs += " @" + tempfile.toAbsolutePath().toString();
+                launchArguments.vmArgs += " \"@" + tempfile.toAbsolutePath().toString() + "\"";
                 launchArguments.classPaths = new String[0];
                 launchArguments.modulePaths = new String[0];
                 context.setArgsfile(tempfile);


### PR DESCRIPTION
Fixes microsoft/vscode-java-debug#822