### PR TITLE
Remove the usage of JDK internal API to avoid breaking JDK 16

### DIFF
--- a/com.microsoft.java.debug.core/pom.xml
+++ b/com.microsoft.java.debug.core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.java</groupId>
         <artifactId>java-debug-parent</artifactId>
-        <version>0.30.0</version>
+        <version>0.30.1</version>
     </parent>
     <artifactId>com.microsoft.java.debug.core</artifactId>
     <packaging>jar</packaging>

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchUtils.java
@@ -16,15 +16,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
@@ -32,8 +31,6 @@ import java.util.jar.Manifest;
 import com.microsoft.java.debug.core.adapter.AdapterUtils;
 
 import org.apache.commons.lang3.ArrayUtils;
-
-import sun.security.action.GetPropertyAction;
 
 public class LaunchUtils {
     private static Set<Path> tempFilesInUse = new HashSet<>();
@@ -109,16 +106,12 @@ public class LaunchUtils {
 
     private static synchronized Path getTmpDir() throws IOException {
         if (tmpdir == null) {
+            Path tmpfile = Files.createTempFile("", UUID.randomUUID().toString());
+            tmpdir = tmpfile.getParent();
             try {
-                tmpdir = Paths.get(java.security.AccessController.doPrivileged(new GetPropertyAction("java.io.tmpdir")));
-            } catch (NullPointerException | InvalidPathException e) {
-                Path tmpfile = Files.createTempFile("", ".tmp");
-                tmpdir = tmpfile.getParent();
-                try {
-                    Files.deleteIfExists(tmpfile);
-                } catch (Exception ex) {
-                    // do nothing
-                }
+                Files.deleteIfExists(tmpfile);
+            } catch (Exception ex) {
+                // do nothing
             }
         }
 

--- a/com.microsoft.java.debug.plugin/.classpath
+++ b/com.microsoft.java.debug.plugin/.classpath
@@ -6,6 +6,6 @@
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry exported="true" kind="lib" path="lib/rxjava-2.1.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/reactive-streams-1.0.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/com.microsoft.java.debug.core-0.30.0.jar" sourcepath="/com.microsoft.java.debug.core"/>
+	<classpathentry exported="true" kind="lib" path="lib/com.microsoft.java.debug.core-0.30.1.jar" sourcepath="/com.microsoft.java.debug.core"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.microsoft.java.debug.plugin/META-INF/MANIFEST.MF
+++ b/com.microsoft.java.debug.plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Java Debug Server Plugin
 Bundle-SymbolicName: com.microsoft.java.debug.plugin;singleton:=true
-Bundle-Version: 0.30.0
+Bundle-Version: 0.30.1
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: com.microsoft.java.debug.plugin.internal.JavaDebuggerServerPlugin
@@ -24,4 +24,4 @@ Bundle-ClassPath: lib/commons-io-2.5.jar,
  .,
  lib/rxjava-2.1.1.jar,
  lib/reactive-streams-1.0.0.jar,
- lib/com.microsoft.java.debug.core-0.30.0.jar
+ lib/com.microsoft.java.debug.core-0.30.1.jar

--- a/com.microsoft.java.debug.plugin/pom.xml
+++ b/com.microsoft.java.debug.plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.microsoft.java</groupId>
         <artifactId>java-debug-parent</artifactId>
-        <version>0.30.0</version>
+        <version>0.30.1</version>
     </parent>
     <artifactId>com.microsoft.java.debug.plugin</artifactId>
     <packaging>eclipse-plugin</packaging>
@@ -45,7 +45,7 @@
                         <artifactItem>
                             <groupId>com.microsoft.java</groupId>
                             <artifactId>com.microsoft.java.debug.core</artifactId>
-                            <version>0.30.0</version>
+                            <version>0.30.1</version>
                         </artifactItem>
                     </artifactItems>
                 </configuration>

--- a/com.microsoft.java.debug.repository/category.xml
+++ b/com.microsoft.java.debug.repository/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <bundle id="com.microsoft.java.debug.plugin" version="0.30.0">
+   <bundle id="com.microsoft.java.debug.plugin" version="0.30.1">
    <category name="javadebug" />
    </bundle>
    <category-def name="javadebug" label="Java Debug Server"/>

--- a/com.microsoft.java.debug.repository/pom.xml
+++ b/com.microsoft.java.debug.repository/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.microsoft.java</groupId>
         <artifactId>java-debug-parent</artifactId>
-        <version>0.30.0</version>
+        <version>0.30.1</version>
     </parent>
 	<artifactId>com.microsoft.java.debug.repository</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <name>${base.name} :: Parent</name>
     <description>The Java Debug Server is an implementation of Visual Studio Code (VSCode) Debug Protocol. It can be used in Visual Studio Code to debug Java programs.</description>
     <url>https://github.com/Microsoft/java-debug</url>
-    <version>0.30.0</version>
+    <version>0.30.1</version>
     <packaging>pom</packaging>
     <properties>
         <base.name>Java Debug Server for Visual Studio Code</base.name>


### PR DESCRIPTION
sun.* is the JDK internal API, and not supposed to be used by the external application.

Fixes microsoft/vscode-java-debug#970