### PR TITLE
modify project order in SourceContainers for increase project priority

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtUtils.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtUtils.java
@@ -213,10 +213,10 @@ public class JdtUtils {
         projects.stream().distinct().map(project -> JdtUtils.getJavaProject(project))
             .filter(javaProject -> javaProject != null && javaProject.exists())
             .forEach(javaProject -> {
-                // Add source containers associated with the project's runtime classpath entries.
-                containers.addAll(Arrays.asList(getSourceContainers(javaProject, calculated)));
                 // Add source containers associated with the project's source folders.
                 containers.add(new JavaProjectSourceContainer(javaProject));
+                // Add source containers associated with the project's runtime classpath entries.
+                containers.addAll(Arrays.asList(getSourceContainers(javaProject, calculated)));
             });
 
         return containers.toArray(new ISourceContainer[0]);


### PR DESCRIPTION
## increase project priority when find source code
> projcetContainer first find
- Because some project dependencies may have to have some jars of source code, and in general, we give priority to debugging the project source code