### PR TITLE
Fix the commons-io version issue in project file

### DIFF
--- a/com.microsoft.java.debug.plugin/.classpath
+++ b/com.microsoft.java.debug.plugin/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.5.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.10.0.jar"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry exported="true" kind="lib" path="lib/rxjava-2.1.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/reactive-streams-1.0.0.jar"/>

--- a/com.microsoft.java.debug.plugin/META-INF/MANIFEST.MF
+++ b/com.microsoft.java.debug.plugin/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.commons.lang3,
  org.eclipse.lsp4j,
  com.google.guava
-Bundle-ClassPath: lib/commons-io-2.5.jar,
+Bundle-ClassPath: lib/commons-io-2.10.0.jar,
  .,
  lib/rxjava-2.1.1.jar,
  lib/reactive-streams-1.0.0.jar,


### PR DESCRIPTION
This is a follow-up to PR #380. Previous PR updated commons-io to 2.10.0 to fix vulnerability, but missed updating the library version in eclipse project file.