### PR TITLE
Fix: classpath is not generated into argfile when using shortCommanLine=argfile

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchUtils.java
@@ -73,11 +73,11 @@ public class LaunchUtils {
     public static synchronized Path generateArgfile(String[] classPaths, String[] modulePaths) throws IOException {
         String argfile = "";
         if (ArrayUtils.isNotEmpty(classPaths)) {
-            argfile = "-classpath \"" + String.join(File.pathSeparator, classPaths) + "\"";
+            argfile = "-cp \"" + String.join(File.pathSeparator, classPaths) + "\"";
         }
 
         if (ArrayUtils.isNotEmpty(modulePaths)) {
-            argfile = " --module-path \"" + String.join(File.pathSeparator, modulePaths) + "\"";
+            argfile += " --module-path \"" + String.join(File.pathSeparator, modulePaths) + "\"";
         }
 
         argfile = argfile.replace("\\", "\\\\");


### PR DESCRIPTION
Fixes microsoft/vscode-java-debug#1047