### PR TITLE
if listing the variable value of a large object fails, just display its basic info

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017-2020 Microsoft Corporation and others.
+* Copyright (c) 2017-2021 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ package com.microsoft.java.debug.core.adapter.handler;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -103,10 +102,8 @@ public class EvaluateRequestHandler implements IDebugRequestHandler {
                                     indexedVariables = ((IntegerValue) sizeValue).value();
                                 }
                             }
-                        } catch (CancellationException | IllegalArgumentException | InterruptedException
-                                | ExecutionException | UnsupportedOperationException e) {
-                            logger.log(Level.INFO,
-                                    String.format("Failed to get the logical size for the type %s.", value.type().name()), e);
+                        } catch (Exception e) {
+                            logger.log(Level.INFO, "Failed to get the logical size of the variable", e);
                         }
                     }
                     int referenceId = 0;
@@ -114,20 +111,49 @@ public class EvaluateRequestHandler implements IDebugRequestHandler {
                         referenceId = context.getRecyclableIdPool().addObject(threadId, varProxy);
                     }
 
-                    String valueString = variableFormatter.valueToString(value, options);
+                    boolean hasErrors = false;
+                    String valueString = null;
+                    try {
+                        valueString = variableFormatter.valueToString(value, options);
+                    } catch (OutOfMemoryError e) {
+                        hasErrors = true;
+                        logger.log(Level.SEVERE, "Failed to convert the value of a large object to a string", e);
+                        valueString = "<Unable to display the value of a large object>";
+                    }  catch (Exception e) {
+                        hasErrors = true;
+                        logger.log(Level.SEVERE, "Failed to resolve the variable value", e);
+                        valueString = "<Failed to resolve the variable value due to \"" + e.getMessage() + "\">";
+                    }
+
                     String detailsString = null;
-                    if (sizeValue != null) {
+                    if (hasErrors) {
+                        // If failed to resolve the variable value, skip the details info as well.
+                    } else if (sizeValue != null) {
                         detailsString = "size=" + variableFormatter.valueToString(sizeValue, options);
                     } else if (DebugSettings.getCurrent().showToString) {
-                        detailsString = VariableDetailUtils.formatDetailsValue(value, stackFrameReference.getThread(), variableFormatter, options, engine);
+                        try {
+                            detailsString = VariableDetailUtils.formatDetailsValue(value, stackFrameReference.getThread(), variableFormatter, options, engine);
+                        } catch (OutOfMemoryError e) {
+                            logger.log(Level.SEVERE, "Failed to compute the toString() value of a large object", e);
+                            detailsString = "<Unable to display the details of a large object>";
+                        } catch (Exception e) {
+                            logger.log(Level.SEVERE, "Failed to compute the toString() value", e);
+                            detailsString = "<Failed to resolve the variable details due to \"" + e.getMessage() + "\">";
+                        }
                     }
 
                     if ("clipboard".equals(evalArguments.context) && detailsString != null) {
                         response.body = new Responses.EvaluateResponseBody(detailsString, -1, "String", 0);
                     } else {
+                        String typeString = "";
+                        try {
+                            typeString = variableFormatter.typeToString(value == null ? null : value.type(), options);
+                        } catch (Exception e) {
+                            logger.log(Level.SEVERE, "Failed to resolve the variable type", e);
+                            typeString = "";
+                        }
                         response.body = new Responses.EvaluateResponseBody((detailsString == null) ? valueString : valueString + " " + detailsString,
-                                referenceId, variableFormatter.typeToString(value == null ? null : value.type(), options),
-                                Math.max(indexedVariables, 0));
+                                referenceId, typeString, Math.max(indexedVariables, 0));
                     }
                     return response;
                 }


### PR DESCRIPTION
Fixes microsoft/vscode-java-debug#1044

Since JDI does not provide an efficient way to query whether a variable is a large object or not. One way to mitigate this is to intercept OOM or timeout exceptions that occur when fetching variable information and display a placeholder on these failed variable segments. This way, the user still has the opportunity to view the basic variable information.

**Before** - Variables view just displays an Exception message.
![image](https://user-images.githubusercontent.com/14052197/134346938-1ab647e1-4f76-4bf7-95f8-1c8c548f7db9.png)

**After** - Variables view still lists all variables, but displays a placeholder for the failed variable property.
![image](https://user-images.githubusercontent.com/14052197/134346586-fa5c3bf8-13ad-4685-a536-d296c0084283.png)
