### PR TITLE
Fix step filter: keep method exit request

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StepRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StepRequestHandler.java
@@ -145,12 +145,14 @@ public class StepRequestHandler implements IDebugRequestHandler {
     private void handleDebugEvent(DebugEvent debugEvent, IDebugSession debugSession, IDebugAdapterContext context,
             ThreadState threadState) {
         Event event = debugEvent.event;
+        EventRequestManager eventRequestManager = debugSession.getVM().eventRequestManager();
 
         // When a breakpoint occurs, abort any pending step requests from the same thread.
         if (event instanceof BreakpointEvent || event instanceof ExceptionEvent) {
             long threadId = ((LocatableEvent) event).thread().uniqueID();
             if (threadId == threadState.threadId && threadState.pendingStepRequest != null) {
-                threadState.deleteStepRequests(debugSession.getVM().eventRequestManager());
+                threadState.deleteStepRequest(eventRequestManager);
+                threadState.deleteMethodExitRequest(eventRequestManager);
                 context.getStepResultManager().removeMethodResult(threadId);
                 if (threadState.eventSubscription != null) {
                     threadState.eventSubscription.dispose();
@@ -158,7 +160,7 @@ public class StepRequestHandler implements IDebugRequestHandler {
             }
         } else if (event instanceof StepEvent) {
             ThreadReference thread = ((StepEvent) event).thread();
-            threadState.deleteStepRequests(debugSession.getVM().eventRequestManager());
+            threadState.deleteStepRequest(eventRequestManager);
             if (isStepFiltersConfigured(context.getStepFilters())) {
                 try {
                     if (threadState.pendingStepType == Command.STEPIN) {
@@ -181,6 +183,7 @@ public class StepRequestHandler implements IDebugRequestHandler {
                     // ignore.
                 }
             }
+            threadState.deleteMethodExitRequest(eventRequestManager);
             if (threadState.eventSubscription != null) {
                 threadState.eventSubscription.dispose();
             }
@@ -280,10 +283,13 @@ public class StepRequestHandler implements IDebugRequestHandler {
         Location stepLocation = null;
         Disposable eventSubscription = null;
 
-        public void deleteStepRequests(EventRequestManager manager) {
-            DebugUtility.deleteEventRequestSafely(manager, this.pendingStepRequest);
+        public void deleteMethodExitRequest(EventRequestManager manager) {
             DebugUtility.deleteEventRequestSafely(manager, this.pendingMethodExitRequest);
             this.pendingMethodExitRequest = null;
+        }
+
+        public void deleteStepRequest(EventRequestManager manager) {
+            DebugUtility.deleteEventRequestSafely(manager, this.pendingStepRequest)
             this.pendingStepRequest = null;
         }
     }


### PR DESCRIPTION
When a `StepEvent` is filtered, for instance because of `StepFilters.skipSynthetics`, `ThreadState.pendingMethodExitRequest` should be kept until next `StepEvent`. Otherwise the handler of the next `StepEvent` throws a `NullPointerException`:

```
Caused by: java.lang.NullPointerException
        at com.sun.tools.jdi.MirrorImpl.validateMirror(MirrorImpl.java:67)
        at com.sun.tools.jdi.EventRequestManagerImpl.deleteEventRequest(EventRequestManagerImpl.java:847)
        at com.microsoft.java.debug.core.DebugUtility.deleteEventRequestSafely(DebugUtility.java:514)
        at com.microsoft.java.debug.core.adapter.handler.StepRequestHandler$ThreadState.deleteStepRequests(StepRequestHandler.java:285)
        at com.microsoft.java.debug.core.adapter.handler.StepRequestHandler.handleDebugEvent(StepRequestHandler.java:161)
        at com.microsoft.java.debug.core.adapter.handler.StepRequestHandler.lambda$handle$1(StepRequestHandler.java:87)
        at io.reactivex.internal.observers.LambdaObserver.onNext(LambdaObserver.java:60)
```