### PR TITLE
Make DAP implementation to be encoding-neutral

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProcessConsole.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProcessConsole.java
@@ -129,7 +129,7 @@ public class ProcessConsole {
         }
 
         private void monitor(InputStream input, PublishSubject<String> subject) {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(input, encoding));
+            BufferedReader reader = new BufferedReader(encoding == null ? new InputStreamReader(input) : new InputStreamReader(input, encoding));
             final int BUFFERSIZE = 4096;
             char[] buffer = new char[BUFFERSIZE];
             while (true) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -90,23 +89,21 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
                 "Failed to launch debuggee VM. Missing mainClass or modulePaths/classPaths options in launch configuration.",
                 ErrorCode.ARGUMENT_MISSING);
         }
-        if (StringUtils.isBlank(launchArguments.encoding)) {
-            context.setDebuggeeEncoding(StandardCharsets.UTF_8);
-        } else {
+        if (StringUtils.isNotBlank(launchArguments.encoding)) {
             if (!Charset.isSupported(launchArguments.encoding)) {
                 throw AdapterUtils.createCompletionException(
                     "Failed to launch debuggee VM. 'encoding' options in the launch configuration is not recognized.",
                     ErrorCode.INVALID_ENCODING);
             }
             context.setDebuggeeEncoding(Charset.forName(launchArguments.encoding));
+            if (StringUtils.isBlank(launchArguments.vmArgs)) {
+                launchArguments.vmArgs = String.format("-Dfile.encoding=%s", context.getDebuggeeEncoding().name());
+            } else {
+                // if vmArgs already has the file.encoding settings, duplicate options for jvm will not cause an error, the right most value wins
+                launchArguments.vmArgs = String.format("%s -Dfile.encoding=%s", launchArguments.vmArgs, context.getDebuggeeEncoding().name());
+            }
         }
 
-        if (StringUtils.isBlank(launchArguments.vmArgs)) {
-            launchArguments.vmArgs = String.format("-Dfile.encoding=%s", context.getDebuggeeEncoding().name());
-        } else {
-            // if vmArgs already has the file.encoding settings, duplicate options for jvm will not cause an error, the right most value wins
-            launchArguments.vmArgs = String.format("%s -Dfile.encoding=%s", launchArguments.vmArgs, context.getDebuggeeEncoding().name());
-        }
         context.setLaunchMode(launchArguments.noDebug ? LaunchMode.NO_DEBUG : LaunchMode.DEBUG);
 
         activeLaunchHandler.preLaunch(launchArguments, context);

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2020 Microsoft Corporation and others.
+ * Copyright (c) 2017-2021 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -120,11 +119,7 @@ public class JdtSourceLookUpProvider implements ISourceLookUpProvider {
         String filePath = AdapterUtils.toPath(uri);
         // For file uri, read the file contents directly and pass them to the ast parser.
         if (filePath != null && Files.isRegularFile(Paths.get(filePath))) {
-            Charset cs = (Charset) this.options.get(Constants.DEBUGGEE_ENCODING);
-            if (cs == null) {
-                cs = Charset.defaultCharset();
-            }
-            String source = readFile(filePath, cs);
+            String source = readFile(filePath);
             parser.setSource(source.toCharArray());
             /**
              * See the java doc for { @link ASTParser#setResolveBindings(boolean) }.
@@ -293,10 +288,10 @@ public class JdtSourceLookUpProvider implements ISourceLookUpProvider {
         return null;
     }
 
-    private static String readFile(String filePath, Charset cs) {
+    private static String readFile(String filePath) {
         StringBuilder builder = new StringBuilder();
         try (BufferedReader bufferReader =
-                new BufferedReader(new InputStreamReader(new FileInputStream(filePath), cs))) {
+                new BufferedReader(new InputStreamReader(new FileInputStream(filePath)))) {
             final int BUFFER_SIZE = 4096;
             char[] buffer = new char[BUFFER_SIZE];
             while (true) {


### PR DESCRIPTION
This requires https://github.com/microsoft/vscode-java-debug/pull/1077

This project is an implementation of DAP, it's better to keep encoding neutral. It's the client's responsibility to determine what encoding to use to launch user's application.