### PR TITLE
Migrate to Java 11

### DIFF
--- a/com.microsoft.java.debug.core/.classpath
+++ b/com.microsoft.java.debug.core/.classpath
@@ -13,7 +13,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/com.microsoft.java.debug.core/pom.xml
+++ b/com.microsoft.java.debug.core/pom.xml
@@ -28,8 +28,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -78,21 +78,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-    <profile>
-            <id>default-tools.jar</id>
-            <activation>
-                <jdk>(,9)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                    <version>1.8</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/com.microsoft.java.debug.plugin/.classpath
+++ b/com.microsoft.java.debug.plugin/.classpath
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+			<attribute name="limit-modules" value="java.base,java.logging,java.xml,jdk.jdi,java.compiler"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.10.0.jar"/>
 	<classpathentry kind="src" path="src/main/java"/>

--- a/com.microsoft.java.debug.plugin/META-INF/MANIFEST.MF
+++ b/com.microsoft.java.debug.plugin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Java Debug Server Plugin
 Bundle-SymbolicName: com.microsoft.java.debug.plugin;singleton:=true
 Bundle-Version: 0.34.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: com.microsoft.java.debug.plugin.internal.JavaDebuggerServerPlugin
 Bundle-Vendor: Microsoft

--- a/com.microsoft.java.debug.plugin/pom.xml
+++ b/com.microsoft.java.debug.plugin/pom.xml
@@ -18,6 +18,17 @@
                 <version>${tycho-version}</version>
                 <extensions>true</extensions>
             </plugin>
+             <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-compiler-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>--limit-modules</arg>
+                        <arg>java.base,java.logging,java.xml,jdk.jdi,java.compiler</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainMethodHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainMethodHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2020 Microsoft Corporation and others.
+ * Copyright (c) 2018-2021 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IOpenable;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
@@ -167,7 +168,7 @@ public class ResolveMainMethodHandler {
 
     private static Range getRange(ICompilationUnit typeRoot, IJavaElement element) throws JavaModelException {
         ISourceRange r = ((ISourceReference) element).getNameRange();
-        return JDTUtils.toRange(typeRoot, r.getOffset(), r.getLength());
+        return JDTUtils.toRange((IOpenable) typeRoot, r.getOffset(), r.getLength());
     }
 
     static class MainMethod {

--- a/java.debug.target
+++ b/java.debug.target
@@ -6,17 +6,35 @@
             <unit id="com.ibm.icu.base" version="58.2.0.v20170418-1837"/>
             <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
             <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
-            <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
             <repository location="https://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.equinox.core.sdk.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/releases/2021-12/202112081000/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2019-12/"/>
+            <repository location="https://download.eclipse.org/releases/2021-09/202109151000/"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <!-- <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/releases/2019-12/"/>
+        </location> -->
+        <!-- <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>
             <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.2-2018-12-24_15-46-05-H18/"/>
+        </location> -->
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>
+            <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>

--- a/java.debug.target
+++ b/java.debug.target
@@ -23,15 +23,6 @@
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
             <repository location="https://download.eclipse.org/releases/2021-09/202109151000/"/>
         </location>
-        <!-- <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2019-12/"/>
-        </location> -->
-        <!-- <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>
-            <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.2-2018-12-24_15-46-05-H18/"/>
-        </location> -->
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>
             <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22/"/>

--- a/pom.xml
+++ b/pom.xml
@@ -154,9 +154,9 @@
     </profiles>
     <repositories>
         <repository>
-            <id>201912</id>
+            <id>202112</id>
             <layout>p2</layout>
-            <url>https://download.eclipse.org/releases/2019-12/</url>
+            <url>https://download.eclipse.org/releases/2021-12/202112081000/</url>
         </repository>
         <repository>
             <id>oss.sonatype.org</id>
@@ -173,7 +173,7 @@
         <repository>
             <id>JBOLL.TOOLS</id>
             <layout>p2</layout>
-            <url>https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.0-2018-05-16_00-46-30-H11</url>
+            <url>https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22/</url>
         </repository>
         <repository>
             <id>orbit</id>


### PR DESCRIPTION
Previously opening java-debug project in VS Code, it reports lots of errors about JDI classes. See the issue https://github.com/redhat-developer/vscode-java/issues/1551

Now that the Java Language Support Extension has embedded JRE 17 to run all Java extensions, it's time to migrate the Java Debug extension to Java 11. 

Meanwhile, with this PR, it supports running unit tests for Java Debug through VS Code Test Explorer.

Close #388