### PR TITLE
Limit search scope of main class to source files and the specified project or paths

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainClassHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainClassHandler.java
@@ -97,7 +97,7 @@ public class ResolveMainClassHandler {
         return resolveMainClassUnderPaths(Collections.emptyList());
     }
 
-    private List<ResolutionItem> resolveMainClassUnderPaths(List<IPath> targetProjectPath) {
+    private List<ResolutionItem> resolveMainClassUnderPaths(List<IPath> parentPaths) {
         // Limit to search main method from source code only.
         IJavaSearchScope searchScope = SearchEngine.createJavaSearchScope(ProjectUtils.getJavaProjects(),
             IJavaSearchScope.REFERENCED_PROJECTS | IJavaSearchScope.SOURCES);
@@ -125,9 +125,9 @@ public class ResolveMainClassHandler {
                                         }
                                     }
                                     String projectName = ProjectsManager.DEFAULT_PROJECT_NAME.equals(project.getName()) ? null : project.getName();
-                                    if (targetProjectPath.isEmpty()
-                                        || ResourceUtils.isContainedIn(project.getLocation(), targetProjectPath)
-                                        || isContainedInInvisibleProject(project, targetProjectPath)) {
+                                    if (parentPaths.isEmpty()
+                                        || ResourceUtils.isContainedIn(project.getLocation(), parentPaths)
+                                        || isContainedInInvisibleProject(project, parentPaths)) {
                                         String filePath = null;
 
                                         if (match.getResource() instanceof IFile) {

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainClassHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainClassHandler.java
@@ -163,7 +163,8 @@ public class ResolveMainClassHandler {
 
     private List<ResolutionItem> resolveMainClassUnderProject(final String projectName) {
         // Limit to search main method from source code only.
-        IJavaSearchScope searchScope = SearchEngine.createJavaSearchScope(ProjectUtils.getJavaProjects(),
+        IJavaProject javaProject = ProjectUtils.getJavaProject(projectName);
+        IJavaSearchScope searchScope = SearchEngine.createJavaSearchScope(javaProject == null ? new IJavaProject[0] : new IJavaProject[] {javaProject},
             IJavaSearchScope.REFERENCED_PROJECTS | IJavaSearchScope.SOURCES);
         SearchPattern pattern = SearchPattern.createPattern("main(String[]) void", IJavaSearchConstants.METHOD,
                 IJavaSearchConstants.DECLARATIONS, SearchPattern.R_CASE_SENSITIVE | SearchPattern.R_EXACT_MATCH);
@@ -188,17 +189,16 @@ public class ResolveMainClassHandler {
                                             mainClass = moduleName + "/" + mainClass;
                                         }
                                     }
-                                    if (Objects.equals(projectName, project.getName())) {
-                                        String filePath = null;
-                                        if (match.getResource() instanceof IFile) {
-                                            try {
-                                                filePath = match.getResource().getLocation().toOSString();
-                                            } catch (Exception ex) {
-                                                // ignore
-                                            }
+
+                                    String filePath = null;
+                                    if (match.getResource() instanceof IFile) {
+                                        try {
+                                            filePath = match.getResource().getLocation().toOSString();
+                                        } catch (Exception ex) {
+                                            // ignore
                                         }
-                                        res.add(new ResolutionItem(mainClass, projectName, filePath));
                                     }
+                                    res.add(new ResolutionItem(mainClass, projectName, filePath));
                                 }
                             }
                         }


### PR DESCRIPTION
- Allow searching main class from the specified project name
- Limit search scope of search engine to SOURCES, this can boost main class resolving performance a lot