### PR TITLE
customRequest 'processId' to get the debugging Java process id

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
@@ -130,7 +130,7 @@ public class DebugAdapter implements IDebugAdapter {
 
         // NO_DEBUG mode only
         registerHandlerForNoDebug(new DisconnectRequestWithoutDebuggingHandler());
-
+        registerHandlerForNoDebug(new ProcessIdHandler());
     }
 
     private void registerHandlerForDebug(IDebugRequestHandler handler) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
@@ -32,6 +32,7 @@ import com.microsoft.java.debug.core.adapter.handler.HotCodeReplaceHandler;
 import com.microsoft.java.debug.core.adapter.handler.InitializeRequestHandler;
 import com.microsoft.java.debug.core.adapter.handler.InlineValuesRequestHandler;
 import com.microsoft.java.debug.core.adapter.handler.LaunchRequestHandler;
+import com.microsoft.java.debug.core.adapter.handler.ProcessIdHandler;
 import com.microsoft.java.debug.core.adapter.handler.RefreshVariablesHandler;
 import com.microsoft.java.debug.core.adapter.handler.RestartFrameHandler;
 import com.microsoft.java.debug.core.adapter.handler.ScopesRequestHandler;
@@ -125,6 +126,7 @@ public class DebugAdapter implements IDebugAdapter {
         registerHandlerForDebug(new SetDataBreakpointsRequestHandler());
         registerHandlerForDebug(new InlineValuesRequestHandler());
         registerHandlerForDebug(new RefreshVariablesHandler());
+        registerHandlerForDebug(new ProcessIdHandler());
 
         // NO_DEBUG mode only
         registerHandlerForNoDebug(new DisconnectRequestWithoutDebuggingHandler());

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
@@ -54,6 +54,9 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     private Path classpathJar = null;
     private Path argsfile = null;
 
+    private long shellProcessId = -1;
+    private long processId = -1;
+
     private IdCollection<String> sourceReferences = new IdCollection<>();
     private RecyclableObjectPool<Long, Object> recyclableIdPool = new RecyclableObjectPool<>();
     private IVariableFormatter variableFormatter = VariableFormatterFactory.createVariableFormatter();
@@ -325,5 +328,25 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     @Override
     public IStepResultManager getStepResultManager() {
         return stepResultManager;
+    }
+
+    @Override
+    public long getProcessId() {
+        return this.processId;
+    }
+
+    @Override
+    public long getShellProcessId() {
+        return this.shellProcessId;
+    }
+
+    @Override
+    public void setProcessId(long processId) {
+        this.processId = processId;
+    }
+
+    @Override
+    public void setShellProcessId(long shellProcessId) {
+        this.shellProcessId = shellProcessId;
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
@@ -128,4 +128,12 @@ public interface IDebugAdapterContext {
     IBreakpointManager getBreakpointManager();
 
     IStepResultManager getStepResultManager();
+
+    void setShellProcessId(long shellProcessId);
+
+    long getShellProcessId();
+
+    void setProcessId(long processId);
+
+    long getProcessId();
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -138,6 +138,17 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
         }
 
         return launch(launchArguments, response, context).thenCompose(res -> {
+            long processId = context.getProcessId();
+            long shellProcessId = context.getShellProcessId();
+            if (context.getDebuggeeProcess() != null) {
+                processId = context.getDebuggeeProcess().pid();
+            }
+
+            // If processId or shellProcessId exist, send a notification to client.
+            if (processId > 0 || shellProcessId > 0) {
+                context.getProtocolServer().sendEvent(new Events.ProcessIdNotification(processId, shellProcessId));
+            }
+
             LaunchUtils.releaseTempLaunchFile(context.getClasspathJar());
             LaunchUtils.releaseTempLaunchFile(context.getArgsfile());
             if (res.success) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
@@ -105,7 +105,8 @@ public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
                         if (runResponse.success) {
                             try {
                                 try {
-                                    RunInTerminalResponseBody terminalResponse = JsonUtils.fromJson(JsonUtils.toJson(runResponse.body), RunInTerminalResponseBody.class);
+                                    RunInTerminalResponseBody terminalResponse = JsonUtils.fromJson(
+                                        JsonUtils.toJson(runResponse.body), RunInTerminalResponseBody.class);
                                     context.setProcessId(terminalResponse.processId);
                                     context.setShellProcessId(terminalResponse.shellProcessId);
                                 } catch (JsonSyntaxException e) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugException;
 import com.microsoft.java.debug.core.DebugSession;
@@ -45,6 +46,7 @@ import com.microsoft.java.debug.core.protocol.Requests.CONSOLE;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 import com.microsoft.java.debug.core.protocol.Requests.LaunchArguments;
 import com.microsoft.java.debug.core.protocol.Requests.RunInTerminalRequestArguments;
+import com.microsoft.java.debug.core.protocol.Responses.RunInTerminalResponseBody;
 import com.sun.jdi.VirtualMachine;
 import com.sun.jdi.connect.Connector;
 import com.sun.jdi.connect.IllegalConnectorArgumentsException;
@@ -102,6 +104,13 @@ public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
                     if (runResponse != null) {
                         if (runResponse.success) {
                             try {
+                                try {
+                                    RunInTerminalResponseBody terminalResponse = JsonUtils.fromJson(JsonUtils.toJson(runResponse.body), RunInTerminalResponseBody.class);
+                                    context.setProcessId(terminalResponse.processId);
+                                    context.setShellProcessId(terminalResponse.shellProcessId);
+                                } catch (JsonSyntaxException e) {
+                                    logger.severe("Failed to resolve runInTerminal response: " + e.toString());
+                                }
                                 VirtualMachine vm = listenConnector.accept(args);
                                 vmHandler.connectVirtualMachine(vm);
                                 context.setDebugSession(new DebugSession(vm));

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ProcessIdHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ProcessIdHandler.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2022 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package com.microsoft.java.debug.core.adapter.handler;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.microsoft.java.debug.core.adapter.IDebugAdapterContext;
+import com.microsoft.java.debug.core.adapter.IDebugRequestHandler;
+import com.microsoft.java.debug.core.protocol.Messages.Response;
+import com.microsoft.java.debug.core.protocol.Requests.Arguments;
+import com.microsoft.java.debug.core.protocol.Requests.Command;
+import com.microsoft.java.debug.core.protocol.Responses.ProcessIdResponseBody;
+
+public class ProcessIdHandler implements IDebugRequestHandler {
+    @Override
+    public List<Command> getTargetCommands() {
+        return Arrays.asList(Command.PROCESSID);
+    }
+
+    @Override
+    public CompletableFuture<Response> handle(Command command, Arguments arguments, Response response,
+            IDebugAdapterContext context) {
+        long processId = context.getProcessId();
+        long shellProcessId = context.getShellProcessId();
+        if (context.getDebuggeeProcess() != null) {
+            processId = context.getDebuggeeProcess().pid();
+        }
+
+        response.body = new ProcessIdResponseBody(processId, shellProcessId);
+        return CompletableFuture.completedFuture(response);
+    }
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Events.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Events.java
@@ -283,4 +283,26 @@ public class Events {
             this.frameId = frameId;
         }
     }
+
+    public static class ProcessIdNotification extends DebugEvent {
+        /**
+         * The process ID.
+         */
+        public long processId = -1;
+        /**
+         * The process ID of the terminal shell if the process is running in a terminal shell.
+         */
+        public long shellProcessId = -1;
+
+        public ProcessIdNotification(long processId) {
+            super("processid");
+            this.processId = processId;
+        }
+
+        public ProcessIdNotification(long processId, long shellProcessId) {
+            super("processid");
+            this.processId = processId;
+            this.shellProcessId = shellProcessId;
+        }
+    }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
@@ -410,6 +410,7 @@ public class Requests {
         PAUSEOTHERS("pauseOthers", ThreadOperationArguments.class),
         INLINEVALUES("inlineValues", InlineValuesArguments.class),
         REFRESHVARIABLES("refreshVariables", RefreshVariablesArguments.class),
+        PROCESSID("processId", Arguments.class),
         UNSUPPORTED("", Arguments.class);
 
         private String command;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Responses.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Responses.java
@@ -39,11 +39,34 @@ public class Responses {
         }
     }
 
-    public static class RunInTerminalResponseBody extends ResponseBody {
-        public int processId;
+    public static class ProcessIdResponseBody extends ResponseBody {
+        /**
+         * The process ID.
+         */
+        public long processId = -1;
+        /**
+         * The process ID of the terminal shell if the process is running in a terminal shell.
+         */
+        public long shellProcessId = -1;
 
-        public RunInTerminalResponseBody(int processId) {
+        public ProcessIdResponseBody(long processId) {
             this.processId = processId;
+        }
+
+        public ProcessIdResponseBody(long processId, long shellProcessId) {
+            this.processId = processId;
+            this.shellProcessId = shellProcessId;
+        }
+    }
+
+    public static class RunInTerminalResponseBody extends ProcessIdResponseBody {
+
+        public RunInTerminalResponseBody(long processId) {
+            super(processId);
+        }
+
+        public RunInTerminalResponseBody(long processId, long shellProcessId) {
+            super(processId, shellProcessId);
         }
     }
 


### PR DESCRIPTION
request: 'processId'
response:
{
  processId?: long;   // The process id
  shellProcessId?: long;   // The process id of the terminal if the Java process is running in a terminal
}
