### PR TITLE
Send logpoint messages to the debug console

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
@@ -44,6 +44,7 @@ import com.microsoft.java.debug.core.protocol.Types;
 import com.sun.jdi.BooleanValue;
 import com.sun.jdi.Field;
 import com.sun.jdi.ObjectReference;
+import com.sun.jdi.StringReference;
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.ThreadReference;
 import com.sun.jdi.Value;
@@ -222,6 +223,11 @@ public class SetBreakpointsRequestHandler implements IDebugRequestHandler {
                 context.getProtocolServer().sendEvent(new Events.UserNotificationEvent(
                     Events.UserNotificationEvent.NotificationType.ERROR,
                     String.format("[Logpoint] Log message '%s' error: %s", breakpoint.getLogMessage(), ex.getMessage())));
+            } else if (value != null) {
+                if (value instanceof StringReference) {
+                    String message = ((StringReference) value).value();
+                    context.getProtocolServer().sendEvent(new Events.LogpointEvent(message));
+                }
             }
             return true;
         } else {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
@@ -226,7 +226,8 @@ public class SetBreakpointsRequestHandler implements IDebugRequestHandler {
             } else if (value != null) {
                 if (value instanceof StringReference) {
                     String message = ((StringReference) value).value();
-                    context.getProtocolServer().sendEvent(new Events.LogpointEvent(message));
+                    context.getProtocolServer().sendEvent(Events.OutputEvent.createConsoleOutput(
+                        message + System.lineSeparator()));
                 }
             }
             return true;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Events.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Events.java
@@ -246,6 +246,19 @@ public class Events {
         }
     }
 
+    public static class LogpointEvent extends DebugEvent {
+
+        public String message;
+
+        /**
+         * Constructor.
+         */
+        public LogpointEvent(String message) {
+            super("logpoint");
+            this.message = message;
+        }
+    }
+
     public static enum InvalidatedAreas {
         @SerializedName("all")
         ALL,

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Events.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Events.java
@@ -246,19 +246,6 @@ public class Events {
         }
     }
 
-    public static class LogpointEvent extends DebugEvent {
-
-        public String message;
-
-        /**
-         * Constructor.
-         */
-        public LogpointEvent(String message) {
-            super("logpoint");
-            this.message = message;
-        }
-    }
-
     public static enum InvalidatedAreas {
         @SerializedName("all")
         ALL,

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/eval/JdtEvaluationProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/eval/JdtEvaluationProvider.java
@@ -226,9 +226,9 @@ public class JdtEvaluationProvider implements IEvaluationProvider {
         }
 
         if (arguments.size() > 0) {
-            return "System.out.println(String.format(\"" + format + "\"," + String.join(",", arguments) + "))";
+            return "String.format(\"" + format + "\"," + String.join(",", arguments) + ")";
         } else {
-            return "System.out.println(\"" + format + "\")";
+            return "\"" + format + "\"";
         }
     }
 


### PR DESCRIPTION
This change sends logpoint messages as protocol events to the vscode-java-debug extension, instead of printing them to `System.out` of the process being debugged.

Fixes microsoft/vscode-java-debug#710