### PR TITLE
Mark native frames and unavailable methods as subtle

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StackTraceRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StackTraceRequestHandler.java
@@ -95,7 +95,9 @@ public class StackTraceRequestHandler implements IDebugRequestHandler {
         String methodName = formatMethodName(method, true, true);
         int lineNumber = AdapterUtils.convertLineNumber(location.lineNumber(), context.isDebuggerLinesStartAt1(), context.isClientLinesStartAt1());
         // Line number returns -1 if the information is not available; specifically, always returns -1 for native methods.
+        String presentationHint = null;
         if (lineNumber < 0) {
+            presentationHint = "subtle";
             if (method.isNative()) {
                 // For native method, display a tip text "native method" in the Call Stack View.
                 methodName += "[native method]";
@@ -105,7 +107,7 @@ public class StackTraceRequestHandler implements IDebugRequestHandler {
                 clientSource = null;
             }
         }
-        return new Types.StackFrame(frameId, methodName, clientSource, lineNumber, context.isClientColumnsStartAt1() ? 1 : 0);
+        return new Types.StackFrame(frameId, methodName, clientSource, lineNumber, context.isClientColumnsStartAt1() ? 1 : 0, presentationHint);
     }
 
     private Types.Source convertDebuggerSourceToClient(Location location, IDebugAdapterContext context) throws URISyntaxException {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Types.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Types.java
@@ -43,6 +43,8 @@ public class Types {
         public int line;
         public int column;
         public String name;
+        public String presentationHint;
+
 
         /**
          * Constructs a StackFrame with the given information.
@@ -57,13 +59,17 @@ public class Types {
          *          line number of the stack frame
          * @param col
          *          column number of the stack frame
+         * @param presentationHint
+         *          An optional hint for how to present this frame in the UI.
+         *          Values: 'normal', 'label', 'subtle'
          */
-        public StackFrame(int id, String name, Source src, int ln, int col) {
+        public StackFrame(int id, String name, Source src, int ln, int col, String presentationHint) {
             this.id = id;
             this.name = name;
             this.source = src;
             this.line = ln;
             this.column = col;
+            this.presentationHint = presentationHint;
         }
     }
 


### PR DESCRIPTION
This causes some clients to display the frames in a different way, e.g
by graying them out.
