### PR TITLE
Capture Java process pid and display debug toolbar when running Java in terminal

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestWithoutDebuggingHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestWithoutDebuggingHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2018 Microsoft Corporation and others.
+* Copyright (c) 2018-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
 *******************************************************************************/
 
 package com.microsoft.java.debug.core.adapter.handler;
+
+import java.util.Optional;
 
 import com.microsoft.java.debug.core.adapter.IDebugAdapterContext;
 import com.microsoft.java.debug.core.protocol.Messages.Response;
@@ -25,6 +27,11 @@ public class DisconnectRequestWithoutDebuggingHandler extends AbstractDisconnect
         Process debuggeeProcess = context.getDebuggeeProcess();
         if (debuggeeProcess != null && disconnectArguments.terminateDebuggee) {
             debuggeeProcess.destroy();
+        } else if (context.getProcessId() > 0 && disconnectArguments.terminateDebuggee) {
+            Optional<ProcessHandle> debuggeeHandle = ProcessHandle.of(context.getProcessId());
+            if (debuggeeHandle.isPresent()) {
+                debuggeeHandle.get().destroy();
+            }
         }
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchUtils.java
@@ -171,7 +171,7 @@ public class LaunchUtils {
             String line;
             String javaExeName = Paths.get(javaCommand).toFile().getName().replaceFirst("\\.exe$", "");
 
-            Process p = Runtime.getRuntime().exec(new String[] { psCommand, "-l" });
+            Process p = Runtime.getRuntime().exec(new String[] {psCommand, "-l"});
             input = new BufferedReader(new InputStreamReader(p.getInputStream()));
             /**
              * Here is a sample output when running ps.exe in bash of cygwin/MINGW64.

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchUtils.java
@@ -171,7 +171,7 @@ public class LaunchUtils {
             String line;
             String javaExeName = Paths.get(javaCommand).toFile().getName().replaceFirst("\\.exe$", "");
 
-            Process p = Runtime.getRuntime().exec(psCommand);
+            Process p = Runtime.getRuntime().exec(new String[] { psCommand, "-l" });
             input = new BufferedReader(new InputStreamReader(p.getInputStream()));
             /**
              * Here is a sample output when running ps.exe in bash of cygwin/MINGW64.

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -116,6 +116,12 @@ public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
                                 vmHandler.connectVirtualMachine(vm);
                                 context.setDebugSession(new DebugSession(vm));
                                 logger.info("Launching debuggee in terminal console succeeded.");
+                                if (context.getShellProcessId() > 0) {
+                                    ProcessHandle debuggeeProcess = LaunchUtils.findJavaProcessInTerminalShell(context.getShellProcessId(), cmds[0], 0);
+                                    if (debuggeeProcess != null) {
+                                        context.setProcessId(debuggeeProcess.pid());
+                                    }
+                                }
                                 resultFuture.complete(response);
                             } catch (TransportTimeoutException e) {
                                 int commandLength = StringUtils.length(launchArguments.cwd) + 1;


### PR DESCRIPTION
It does two things in this PR:
- Capture the Java process pid when running Java in a terminal shell.
   This is a follow-up of https://github.com/microsoft/java-debug/pull/399. Both the SpringBoot Dashboard and Spring Tools extension have the requirement to get the running Java pid from Java debugger, so it makes sense to support it in Java debugger directly for reuse.

   Since the DAP just returns the shell process pid when running Java in a terminal shell, the debugger have to find the running Java process based on the shell pid. In the standard shell environment such as PowerShell, cmd, Linux/macOS shells, the shell process is parent of Java process, it's easy to find Java subprocess from process tree. But this approach fails when using Git Bash as the default terminal, because the launched Java process is no longer a descendant process of the shell process.

  Git bash is based on MSYS2 platform, which is a fork of Cygwin technology. When running Cygwin exe in Windows, it runs at an emulator layer. So its process tree is not same as Windows process tree. Each Cygwin process has a mapped Windows pid. Running ps command in bash can list the cygwin's pid, cygwin's ppid and its winpid. Based on ps command, it's possible to find the running Java process and its parent Git bash process.

- Display the debug toolbar when using "Run Java" action to run Java in terminal without debugging.
   Keep the debug session alive until the Java process exits. This fixes microsoft/vscode-java-debug#1166
   ![image](https://user-images.githubusercontent.com/14052197/169682717-60326592-8d9d-475f-a47d-12851fb36286.png)