### PR TITLE
Naming Java terminal with mainClass name

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
@@ -77,7 +77,7 @@ public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
             String address = listenConnector.startListening(args);
 
             final String[] names = launchArguments.mainClass.split("[/\\.]");
-            final String terminalName = "Debug " + names[names.length - 1];
+            final String terminalName = "Debug: " + names[names.length - 1];
             String[] cmds = LaunchRequestHandler.constructLaunchCommands(launchArguments, false, address);
             RunInTerminalRequestArguments requestArgs = null;
             if (launchArguments.console == CONSOLE.integratedTerminal) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
@@ -58,7 +58,6 @@ public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
 
     protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private static final int ATTACH_TERMINAL_TIMEOUT = 20 * 1000;
-    private static final String TERMINAL_TITLE = "Java Debug Console";
     protected static final long RUNINTERMINAL_TIMEOUT = 10 * 1000;
     private VMHandler vmHandler = new VMHandler();
 
@@ -77,6 +76,8 @@ public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
             ((Connector.IntegerArgument) args.get("timeout")).setValue(ATTACH_TERMINAL_TIMEOUT);
             String address = listenConnector.startListening(args);
 
+            final String[] names = launchArguments.mainClass.split("[/\\.]");
+            final String terminalName = "Debug " + names[names.length - 1];
             String[] cmds = LaunchRequestHandler.constructLaunchCommands(launchArguments, false, address);
             RunInTerminalRequestArguments requestArgs = null;
             if (launchArguments.console == CONSOLE.integratedTerminal) {
@@ -84,13 +85,13 @@ public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
                         cmds,
                         launchArguments.cwd,
                         launchArguments.env,
-                        TERMINAL_TITLE);
+                        terminalName);
             } else {
                 requestArgs = RunInTerminalRequestArguments.createExternalTerminal(
                         cmds,
                         launchArguments.cwd,
                         launchArguments.env,
-                        TERMINAL_TITLE);
+                        terminalName);
             }
             Request request = new Request(Command.RUNINTERMINAL.getName(),
                     (JsonObject) JsonUtils.toJsonTree(requestArgs, RunInTerminalRequestArguments.class));

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithoutDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithoutDebuggingDelegate.java
@@ -92,7 +92,7 @@ public class LaunchWithoutDebuggingDelegate implements ILaunchDelegate {
         final String launchInTerminalErrorFormat = "Failed to launch debuggee in terminal. Reason: %s";
 
         final String[] names = launchArguments.mainClass.split("[/\\.]");
-        final String terminalName = "Run " + names[names.length - 1];
+        final String terminalName = "Run: " + names[names.length - 1];
         String[] cmds = LaunchRequestHandler.constructLaunchCommands(launchArguments, false, null);
         RunInTerminalRequestArguments requestArgs = null;
         if (launchArguments.console == CONSOLE.integratedTerminal) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithoutDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithoutDebuggingDelegate.java
@@ -40,7 +40,6 @@ import com.sun.jdi.connect.VMStartException;
 
 public class LaunchWithoutDebuggingDelegate implements ILaunchDelegate {
     protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
-    protected static final String TERMINAL_TITLE = "Java Process Console";
     protected static final long RUNINTERMINAL_TIMEOUT = 10 * 1000;
     private Consumer<IDebugAdapterContext> terminateHandler;
 
@@ -92,14 +91,16 @@ public class LaunchWithoutDebuggingDelegate implements ILaunchDelegate {
 
         final String launchInTerminalErrorFormat = "Failed to launch debuggee in terminal. Reason: %s";
 
+        final String[] names = launchArguments.mainClass.split("[/\\.]");
+        final String terminalName = "Run " + names[names.length - 1];
         String[] cmds = LaunchRequestHandler.constructLaunchCommands(launchArguments, false, null);
         RunInTerminalRequestArguments requestArgs = null;
         if (launchArguments.console == CONSOLE.integratedTerminal) {
             requestArgs = RunInTerminalRequestArguments.createIntegratedTerminal(cmds, launchArguments.cwd,
-                    launchArguments.env, TERMINAL_TITLE);
+                    launchArguments.env, terminalName);
         } else {
             requestArgs = RunInTerminalRequestArguments.createExternalTerminal(cmds, launchArguments.cwd,
-                    launchArguments.env, TERMINAL_TITLE);
+                    launchArguments.env, terminalName);
         }
         Request request = new Request(Command.RUNINTERMINAL.getName(),
                 (JsonObject) JsonUtils.toJsonTree(requestArgs, RunInTerminalRequestArguments.class));


### PR DESCRIPTION
Fixes microsoft/vscode-java-debug#1164

Naming the terminal for "Run Java" action as "Run \<MainClassName\>". For "Debug Java" action, naming it as "Debug \<MainClassName\>". The same debug session will reuse the same terminal. And it can also differentiate the Run and Debug behavior.

![image](https://user-images.githubusercontent.com/14052197/169737199-408ea565-5065-4a02-8ce7-b08d27738343.png)