### PR TITLE
Add support for lambda breakpoints

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
@@ -298,7 +298,7 @@ public class Breakpoint implements IBreakpoint {
                     request.addCountFilter(hitCount);
                 }
                 request.enable();
-                request.putProperty(IBreakpoint.REQUEST_TYPE_FUNCTIONAL, Boolean.valueOf(this.methodSignature != null));
+                request.putProperty(IBreakpoint.REQUEST_TYPE, computeRequestType());
                 newRequests.add(request);
             } catch (VMDisconnectedException ex) {
                 // enable breakpoint operation may be executing while JVM is terminating, thus the VMDisconnectedException may be
@@ -308,6 +308,18 @@ public class Breakpoint implements IBreakpoint {
         });
 
         return newRequests;
+    }
+
+    private Object computeRequestType() {
+        if (this.methodSignature == null) {
+            return IBreakpoint.REQUEST_TYPE_LINE;
+        }
+
+        if (this.methodSignature.startsWith("lambda$")) {
+            return IBreakpoint.REQUEST_TYPE_LAMBDA;
+        } else {
+            return IBreakpoint.REQUEST_TYPE_METHOD;
+        }
     }
 
     @Override

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
@@ -115,12 +115,19 @@ public class Breakpoint implements IBreakpoint {
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof IBreakpoint)) {
+        if (!(obj instanceof Breakpoint)) {
             return super.equals(obj);
         }
 
-        IBreakpoint breakpoint = (IBreakpoint) obj;
-        return Objects.equals(this.className(), breakpoint.className()) && this.getLineNumber() == breakpoint.getLineNumber();
+        Breakpoint breakpoint = (Breakpoint) obj;
+        return Objects.equals(this.className(), breakpoint.className())
+                && this.getLineNumber() == breakpoint.getLineNumber()
+                && Objects.equals(this.methodSignature, breakpoint.methodSignature);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.className, this.lineNumber, this.methodSignature);
     }
 
     @Override

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EvaluatableBreakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EvaluatableBreakpoint.java
@@ -11,15 +11,15 @@
 
 package com.microsoft.java.debug.core;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.sun.jdi.event.ThreadDeathEvent;
+import org.apache.commons.lang3.StringUtils;
+
 import com.sun.jdi.ThreadReference;
 import com.sun.jdi.VirtualMachine;
+import com.sun.jdi.event.ThreadDeathEvent;
 
 import io.reactivex.disposables.Disposable;
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IBreakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IBreakpoint.java
@@ -15,7 +15,13 @@ import java.util.concurrent.CompletableFuture;
 
 public interface IBreakpoint extends IDebugResource {
 
-    String REQUEST_TYPE_FUNCTIONAL = "functional";
+    String REQUEST_TYPE = "request_type";
+
+    int REQUEST_TYPE_LINE = 0;
+
+    int REQUEST_TYPE_METHOD = 1;
+
+    int REQUEST_TYPE_LAMBDA = 2;
 
     String className();
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/AdapterUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/AdapterUtils.java
@@ -112,6 +112,24 @@ public class AdapterUtils {
     }
 
     /**
+     * Convert the source platform's column number to the target platform's column
+     * number.
+     *
+     * @param column
+     *                              the column number from the source platform
+     * @param sourceColumnsStartAt1
+     *                              the source platform's column starts at 1 or not
+     * @return the new column number
+     */
+    public static int convertColumnNumber(int column, boolean sourceColumnsStartAt1) {
+        if (sourceColumnsStartAt1) {
+            return column - 1;
+        } else {
+            return column;
+        }
+    }
+
+    /**
      * Convert the source platform's path format to the target platform's path format.
      *
      * @param path

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/BreakpointManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/BreakpointManager.java
@@ -79,12 +79,12 @@ public class BreakpointManager implements IBreakpointManager {
 
         // Compute the breakpoints that are newly added.
         List<IBreakpoint> toAdd = new ArrayList<>();
-        List<Integer> visitedLineNumbers = new ArrayList<>();
+        List<Integer> visitedBreakpoints = new ArrayList<>();
         for (IBreakpoint breakpoint : breakpoints) {
-            IBreakpoint existed = breakpointMap.get(String.valueOf(breakpoint.getLineNumber()));
+            IBreakpoint existed = breakpointMap.get(String.valueOf(breakpoint.hashCode()));
             if (existed != null) {
                 result.add(existed);
-                visitedLineNumbers.add(existed.getLineNumber());
+                visitedBreakpoints.add(existed.hashCode());
                 continue;
             } else {
                 result.add(breakpoint);
@@ -95,7 +95,7 @@ public class BreakpointManager implements IBreakpointManager {
         // Compute the breakpoints that are no longer listed.
         List<IBreakpoint> toRemove = new ArrayList<>();
         for (IBreakpoint breakpoint : breakpointMap.values()) {
-            if (!visitedLineNumbers.contains(breakpoint.getLineNumber())) {
+            if (!visitedBreakpoints.contains(breakpoint.hashCode())) {
                 toRemove.add(breakpoint);
             }
         }
@@ -113,7 +113,7 @@ public class BreakpointManager implements IBreakpointManager {
             for (IBreakpoint breakpoint : breakpoints) {
                 breakpoint.putProperty("id", this.nextBreakpointId.getAndIncrement());
                 this.breakpoints.add(breakpoint);
-                breakpointMap.put(String.valueOf(breakpoint.getLineNumber()), breakpoint);
+                breakpointMap.put(String.valueOf(breakpoint.hashCode()), breakpoint);
             }
         }
     }
@@ -133,7 +133,7 @@ public class BreakpointManager implements IBreakpointManager {
                     // Destroy the breakpoint on the debugee VM.
                     breakpoint.close();
                     this.breakpoints.remove(breakpoint);
-                    breakpointMap.remove(String.valueOf(breakpoint.getLineNumber()));
+                    breakpointMap.remove(String.valueOf(breakpoint.hashCode()));
                 } catch (Exception e) {
                     logger.log(Level.SEVERE, String.format("Remove breakpoint exception: %s", e.toString()), e);
                 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Types.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Types.java
@@ -202,6 +202,7 @@ public class Types {
 
     public static class SourceBreakpoint {
         public int line;
+        public int column;
         public String hitCondition;
         public String condition;
         public String logMessage;
@@ -214,6 +215,16 @@ public class Types {
          */
         public SourceBreakpoint(int line, String condition, String hitCondition) {
             this.line = line;
+            this.condition = condition;
+            this.hitCondition = hitCondition;
+        }
+
+        /**
+         * Constructor.
+         */
+        public SourceBreakpoint(int line, String condition, String hitCondition, int column) {
+            this.line = line;
+            this.column = column;
             this.condition = condition;
             this.hitCondition = hitCondition;
         }

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/BreakpointLocationLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/BreakpointLocationLocator.java
@@ -20,7 +20,8 @@ public class BreakpointLocationLocator
 
     private IMethodBinding methodBinding;
 
-    public BreakpointLocationLocator(CompilationUnit compilationUnit, int lineNumber, boolean bindingsResolved,
+    public BreakpointLocationLocator(CompilationUnit compilationUnit, int lineNumber,
+            boolean bindingsResolved,
             boolean bestMatch) {
         super(compilationUnit, lineNumber, bindingsResolved, bestMatch);
     }
@@ -45,7 +46,7 @@ public class BreakpointLocationLocator
         if (this.methodBinding == null) {
             return null;
         }
-        return toSignature(this.methodBinding);
+        return toSignature(this.methodBinding, getMethodName());
     }
 
     /**
@@ -70,13 +71,12 @@ public class BreakpointLocationLocator
         return super.getFullyQualifiedTypeName();
     }
 
-    private String toSignature(IMethodBinding binding) {
+    static String toSignature(IMethodBinding binding, String name) {
         // use key for now until JDT core provides a public API for this.
         // "Ljava/util/Arrays;.asList<T:Ljava/lang/Object;>([TT;)Ljava/util/List<TT;>;"
         // "([Ljava/lang/String;)V|Ljava/lang/InterruptedException;"
         String signatureString = binding.getKey();
         if (signatureString != null) {
-            String name = binding.getName();
             int index = signatureString.indexOf(name);
             if (index > -1) {
                 int exceptionIndex = signatureString.indexOf("|", signatureString.lastIndexOf(")"));

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
@@ -38,10 +38,21 @@ public class LambdaExpressionLocator extends ASTVisitor {
             int startPosition = node.getStartPosition();
 
             int startColumn = this.compilationUnit.getColumnNumber(startPosition);
-            int endColumn = this.compilationUnit.getColumnNumber(startPosition + node.getLength());
-            int lineNumber = this.compilationUnit.getLineNumber(startPosition);
+            int endPosition = startPosition + node.getLength();
+            int endColumn = this.compilationUnit.getColumnNumber(endPosition);
+            int startLine = this.compilationUnit.getLineNumber(startPosition);
+            int endLine = this.compilationUnit.getLineNumber(endPosition);
 
-            if (column >= startColumn && column <= endColumn && lineNumber == line) {
+            // lambda on same line:
+            // list.stream().map(i -> i + 1);
+            //
+            // lambda on multiple lines:
+            // list.stream().map(user
+            // -> user.isSystem() ? new SystemUser(user) : new EndUser(user));
+
+            if ((startLine == endLine && column >= startColumn && column <= endColumn && line == startLine)
+                    || (startLine != endLine && line >= startLine && line <= endLine
+                            && (column >= startColumn || column <= endColumn))) {
                 this.lambdaMethodBinding = node.resolveMethodBinding();
                 this.found = true;
                 this.lambdaExpression = node;

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
@@ -37,10 +37,11 @@ public class LambdaExpressionLocator extends ASTVisitor {
         if (column > -1) {
             int startPosition = node.getStartPosition();
 
-            int columnNumber = this.compilationUnit.getColumnNumber(startPosition);
+            int startColumn = this.compilationUnit.getColumnNumber(startPosition);
+            int endColumn = this.compilationUnit.getColumnNumber(startPosition + node.getLength());
             int lineNumber = this.compilationUnit.getLineNumber(startPosition);
 
-            if (column == columnNumber && lineNumber == line) {
+            if (column >= startColumn && column <= endColumn && lineNumber == line) {
                 this.lambdaMethodBinding = node.resolveMethodBinding();
                 this.found = true;
                 this.lambdaExpression = node;

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+* Copyright (c) 2022 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Gayan Perera (gayanper@gmail.com) - initial API and implementation
+*******************************************************************************/
+package com.microsoft.java.debug;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.LambdaExpression;
+
+public class LambdaExpressionLocator extends ASTVisitor {
+    private CompilationUnit compilationUnit;
+    private int line;
+    private int column;
+    private boolean found;
+
+    private IMethodBinding lambdaMethodBinding;
+    private LambdaExpression lambdaExpression;
+
+    public LambdaExpressionLocator(CompilationUnit compilationUnit, int line, int column) {
+        this.compilationUnit = compilationUnit;
+        this.line = line;
+        this.column = column;
+    }
+
+    @Override
+    public boolean visit(LambdaExpression node) {
+        if (column > -1) {
+            int startPosition = node.getStartPosition();
+
+            int columnNumber = this.compilationUnit.getColumnNumber(startPosition);
+            int lineNumber = this.compilationUnit.getLineNumber(startPosition);
+
+            if (column == columnNumber && lineNumber == line) {
+                this.lambdaMethodBinding = node.resolveMethodBinding();
+                this.found = true;
+                this.lambdaExpression = node;
+                return false;
+            }
+        }
+        return super.visit(node);
+    }
+
+    /**
+     * Returns <code>true</code> if a lambda is found at given location.
+     */
+    public boolean isFound() {
+        return found;
+    }
+
+    /**
+     * Returns the signature of lambda method otherwise return null.
+     */
+    public String getMethodSignature() {
+        if (!this.found) {
+            return null;
+        }
+        return BreakpointLocationLocator.toSignature(this.lambdaMethodBinding, getMethodName());
+    }
+
+    /**
+     * Returns the name of lambda method otherwise return null.
+     */
+    public String getMethodName() {
+        if (!this.found) {
+            return null;
+        }
+        String key = this.lambdaMethodBinding.getKey();
+        return key.substring(key.indexOf('.') + 1, key.indexOf('('));
+    }
+
+    /**
+     * Returns the name of the type which the lambda method is found.
+     */
+    public String getFullyQualifiedTypeName() {
+        if (this.found) {
+            ASTNode parent = lambdaExpression.getParent();
+            while (parent != null) {
+                if (parent instanceof AbstractTypeDeclaration) {
+                    AbstractTypeDeclaration declaration = (AbstractTypeDeclaration) parent;
+                    return declaration.resolveBinding().getBinaryName();
+                }
+                parent = parent.getParent();
+            }
+        }
+        return null;
+    }
+}

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
@@ -37,7 +37,7 @@ public class LambdaExpressionLocator extends ASTVisitor {
         // we only support inline breakpoints which are added before the expression part of the
         // lambda. And we don't support lambda blocks since they can be debugged using line
         // breakpoints.
-        if (column > -1 && node.getNodeType() != ASTNode.BLOCK) {
+        if (column > -1) {
             int startPosition = node.getStartPosition();
             int endPosition = node.getBody().getStartPosition();
             int offset = this.compilationUnit.getPosition(line, column);

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
@@ -156,42 +156,45 @@ public class JdtSourceLookUpProvider implements ISourceLookUpProvider {
         String[] fqns = new String[lines.length];
         if (astUnit != null) {
             for (int i = 0; i < lines.length; i++) {
-                // if we have a column, try to find the lambda expression at that column
-                LambdaExpressionLocator lambdaExpressionLocator = new LambdaExpressionLocator(astUnit, lines[i],
-                        columns[i]);
-                astUnit.accept(lambdaExpressionLocator);
-                if (lambdaExpressionLocator.isFound()) {
-                    fqns[i] = lambdaExpressionLocator.getFullyQualifiedTypeName().concat("#")
-                            .concat(lambdaExpressionLocator.getMethodName())
-                            .concat("#").concat(lambdaExpressionLocator.getMethodSignature());
-                } else {
-                    // TODO
-                    // The ValidBreakpointLocationLocator will verify if the current line is a valid
-                    // location or not.
-                    // If so, it will return the fully qualified name of the class type that
-                    // contains the current line.
-                    // Otherwise, it will try to find a valid location from the next lines and
-                    // return it's fully qualified name.
-                    // In current stage, we don't support to move the invalid breakpoint down to the
-                    // next valid location, and just
-                    // mark it as "unverified".
-                    // In future, we could consider supporting to update the breakpoint to a valid
-                    // location.
-                    BreakpointLocationLocator locator = new BreakpointLocationLocator(astUnit, lines[i], true,
-                            true);
-                    astUnit.accept(locator);
-                    // When the final valid line location is same as the original line, that
-                    // represents it's a valid breakpoint.
-                    // Add location type check to avoid breakpoint on method/field which will never
-                    // be hit in current implementation.
-                    if (lines[i] == locator.getLineLocation()
-                            && locator.getLocationType() == BreakpointLocationLocator.LOCATION_LINE) {
-                        fqns[i] = locator.getFullyQualifiedTypeName();
-                    } else if (locator.getLocationType() == BreakpointLocationLocator.LOCATION_METHOD) {
-                        fqns[i] = locator.getFullyQualifiedTypeName().concat("#")
-                                .concat(locator.getMethodName())
-                                .concat("#").concat(locator.getMethodSignature());
+                if (columns[i] > -1) {
+                    // if we have a column, try to find the lambda expression at that column
+                    LambdaExpressionLocator lambdaExpressionLocator = new LambdaExpressionLocator(astUnit, lines[i],
+                            columns[i]);
+                    astUnit.accept(lambdaExpressionLocator);
+                    if (lambdaExpressionLocator.isFound()) {
+                        fqns[i] = lambdaExpressionLocator.getFullyQualifiedTypeName().concat("#")
+                                .concat(lambdaExpressionLocator.getMethodName())
+                                .concat("#").concat(lambdaExpressionLocator.getMethodSignature());
+                        continue;
                     }
+                }
+
+                // TODO
+                // The ValidBreakpointLocationLocator will verify if the current line is a valid
+                // location or not.
+                // If so, it will return the fully qualified name of the class type that
+                // contains the current line.
+                // Otherwise, it will try to find a valid location from the next lines and
+                // return it's fully qualified name.
+                // In current stage, we don't support to move the invalid breakpoint down to the
+                // next valid location, and just
+                // mark it as "unverified".
+                // In future, we could consider supporting to update the breakpoint to a valid
+                // location.
+                BreakpointLocationLocator locator = new BreakpointLocationLocator(astUnit, lines[i], true,
+                        true);
+                astUnit.accept(locator);
+                // When the final valid line location is same as the original line, that
+                // represents it's a valid breakpoint.
+                // Add location type check to avoid breakpoint on method/field which will never
+                // be hit in current implementation.
+                if (lines[i] == locator.getLineLocation()
+                        && locator.getLocationType() == BreakpointLocationLocator.LOCATION_LINE) {
+                    fqns[i] = locator.getFullyQualifiedTypeName();
+                } else if (locator.getLocationType() == BreakpointLocationLocator.LOCATION_METHOD) {
+                    fqns[i] = locator.getFullyQualifiedTypeName().concat("#")
+                            .concat(locator.getMethodName())
+                            .concat("#").concat(locator.getMethodSignature());
                 }
             }
         }

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
@@ -46,6 +46,7 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.LibraryLocation;
 
 import com.microsoft.java.debug.BreakpointLocationLocator;
+import com.microsoft.java.debug.LambdaExpressionLocator;
 import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugException;
 import com.microsoft.java.debug.core.adapter.AdapterUtils;
@@ -155,23 +156,42 @@ public class JdtSourceLookUpProvider implements ISourceLookUpProvider {
         String[] fqns = new String[lines.length];
         if (astUnit != null) {
             for (int i = 0; i < lines.length; i++) {
-                // TODO
-                // The ValidBreakpointLocationLocator will verify if the current line is a valid location or not.
-                // If so, it will return the fully qualified name of the class type that contains the current line.
-                // Otherwise, it will try to find a valid location from the next lines and return it's fully qualified name.
-                // In current stage, we don't support to move the invalid breakpoint down to the next valid location, and just
-                // mark it as "unverified".
-                // In future, we could consider supporting to update the breakpoint to a valid location.
-                BreakpointLocationLocator locator = new BreakpointLocationLocator(astUnit, lines[i], true, true);
-                astUnit.accept(locator);
-                // When the final valid line location is same as the original line, that represents it's a valid breakpoint.
-                // Add location type check to avoid breakpoint on method/field which will never be hit in current implementation.
-                if (lines[i] == locator.getLineLocation()
-                        && locator.getLocationType() == BreakpointLocationLocator.LOCATION_LINE) {
-                    fqns[i] = locator.getFullyQualifiedTypeName();
-                } else if (locator.getLocationType() == BreakpointLocationLocator.LOCATION_METHOD) {
-                    fqns[i] = locator.getFullyQualifiedTypeName().concat("#").concat(locator.getMethodName())
-                            .concat("#").concat(locator.getMethodSignature());
+                // if we have a column, try to find the lambda expression at that column
+                LambdaExpressionLocator lambdaExpressionLocator = new LambdaExpressionLocator(astUnit, lines[i],
+                        columns[i]);
+                astUnit.accept(lambdaExpressionLocator);
+                if (lambdaExpressionLocator.isFound()) {
+                    fqns[i] = lambdaExpressionLocator.getFullyQualifiedTypeName().concat("#")
+                            .concat(lambdaExpressionLocator.getMethodName())
+                            .concat("#").concat(lambdaExpressionLocator.getMethodSignature());
+                } else {
+                    // TODO
+                    // The ValidBreakpointLocationLocator will verify if the current line is a valid
+                    // location or not.
+                    // If so, it will return the fully qualified name of the class type that
+                    // contains the current line.
+                    // Otherwise, it will try to find a valid location from the next lines and
+                    // return it's fully qualified name.
+                    // In current stage, we don't support to move the invalid breakpoint down to the
+                    // next valid location, and just
+                    // mark it as "unverified".
+                    // In future, we could consider supporting to update the breakpoint to a valid
+                    // location.
+                    BreakpointLocationLocator locator = new BreakpointLocationLocator(astUnit, lines[i], true,
+                            true);
+                    astUnit.accept(locator);
+                    // When the final valid line location is same as the original line, that
+                    // represents it's a valid breakpoint.
+                    // Add location type check to avoid breakpoint on method/field which will never
+                    // be hit in current implementation.
+                    if (lines[i] == locator.getLineLocation()
+                            && locator.getLocationType() == BreakpointLocationLocator.LOCATION_LINE) {
+                        fqns[i] = locator.getFullyQualifiedTypeName();
+                    } else if (locator.getLocationType() == BreakpointLocationLocator.LOCATION_METHOD) {
+                        fqns[i] = locator.getFullyQualifiedTypeName().concat("#")
+                                .concat(locator.getMethodName())
+                                .concat("#").concat(locator.getMethodSignature());
+                    }
                 }
             }
         }


### PR DESCRIPTION
The support for method header breakpoints was extended to support
lambda breakpoints using the vscode inline breakpoint feature.