### PR TITLE
Support Show as Binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ hs_err_pid*
 target/
 .settings
 **/.checkstyle
-target/
 bin/
 **/lib/
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
+import com.microsoft.java.debug.core.adapter.formatter.NumericFormatEnum;
 import com.microsoft.java.debug.core.protocol.JsonUtils;
 import com.microsoft.java.debug.core.protocol.Requests.ClassFilters;
 import com.microsoft.java.debug.core.protocol.Requests.StepFilters;
@@ -32,7 +33,7 @@ public final class DebugSettings {
     public int numericPrecision = 0;
     public boolean showStaticVariables = false;
     public boolean showQualifiedNames = false;
-    public boolean showHex = false;
+    public NumericFormatEnum formatType = NumericFormatEnum.DEC; 
     public boolean showLogicalStructure = true;
     public boolean showToString = true;
     public String logLevel;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatEnum.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatEnum.java
@@ -12,6 +12,7 @@
 package com.microsoft.java.debug.core.adapter.formatter;
 
 public enum NumericFormatEnum {
+    BIN,
     HEX,
     OCT,
     DEC

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatter.java
@@ -30,18 +30,15 @@ public class NumericFormatter implements IValueFormatter {
     public static final String NUMERIC_PRECISION_OPTION = "numeric_precision";
     private static final NumericFormatEnum DEFAULT_NUMERIC_FORMAT = NumericFormatEnum.DEC;
     private static final int DEFAULT_NUMERIC_PRECISION = 0;
-    private static final Map<NumericFormatEnum, String> enumFormatMap = new HashMap<>();
 
-    static {
-        enumFormatMap.put(NumericFormatEnum.DEC, "%d");
-        enumFormatMap.put(NumericFormatEnum.HEX, "%#x");
-        enumFormatMap.put(NumericFormatEnum.OCT, "%#o");
-    }
+    private static final String HEX_PREFIX = "0x";
+    private static final String OCT_PREFIX = "0";
+    private static final String BIN_PREFIX = "0b";
 
     /**
      * Get the string representations for an object.
      *
-     * @param obj the value object
+     * @param obj     the value object
      * @param options extra information for printing
      * @return the string representations.
      */
@@ -91,7 +88,6 @@ public class NumericFormatter implements IValueFormatter {
         throw new UnsupportedOperationException(String.format("%s is not a numeric type.", type.name()));
     }
 
-
     /**
      * The conditional function for this formatter.
      *
@@ -122,11 +118,21 @@ public class NumericFormatter implements IValueFormatter {
 
     static String formatNumber(long value, Map<String, Object> options) {
         NumericFormatEnum formatEnum = getNumericFormatOption(options);
-        return String.format(enumFormatMap.get(formatEnum), value);
+        switch (formatEnum) {
+            case HEX:
+                return HEX_PREFIX + Long.toHexString(value);
+            case OCT:
+                return OCT_PREFIX + Long.toOctalString(value);
+            case BIN:
+                return BIN_PREFIX + Long.toBinaryString(value);
+            default:
+                return Long.toString(value);
+        }
     }
 
     private static long parseNumber(String number) {
-        return Long.decode(number);
+        return number.startsWith(BIN_PREFIX)
+            ? Long.parseLong(number.substring(2), 2) : Long.decode(number);
     }
 
     private static double parseFloatDouble(String number) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
@@ -61,7 +61,7 @@ public class EvaluateRequestHandler implements IDebugRequestHandler {
         EvaluateArguments evalArguments = (EvaluateArguments) arguments;
         final boolean showStaticVariables = DebugSettings.getCurrent().showStaticVariables;
         Map<String, Object> options = context.getVariableFormatter().getDefaultOptions();
-        VariableUtils.applyFormatterOptions(options, evalArguments.format != null && evalArguments.format.hex);
+        VariableUtils.applyFormatterOptions(options, evalArguments.format);
         String expression = evalArguments.expression;
 
         if (StringUtils.isBlank(expression)) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/RefreshVariablesHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/RefreshVariablesHandler.java
@@ -18,12 +18,17 @@ import java.util.concurrent.CompletableFuture;
 import com.microsoft.java.debug.core.DebugSettings;
 import com.microsoft.java.debug.core.adapter.IDebugAdapterContext;
 import com.microsoft.java.debug.core.adapter.IDebugRequestHandler;
+import com.microsoft.java.debug.core.adapter.formatter.NumericFormatEnum;
 import com.microsoft.java.debug.core.protocol.Events.InvalidatedAreas;
 import com.microsoft.java.debug.core.protocol.Events.InvalidatedEvent;
 import com.microsoft.java.debug.core.protocol.Messages.Response;
+import com.microsoft.java.debug.core.protocol.Requests;
 import com.microsoft.java.debug.core.protocol.Requests.Arguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 import com.microsoft.java.debug.core.protocol.Requests.RefreshVariablesArguments;
+
+import static com.microsoft.java.debug.core.adapter.formatter.NumericFormatEnum.HEX;
+import static com.microsoft.java.debug.core.adapter.formatter.NumericFormatEnum.DEC;
 
 public class RefreshVariablesHandler implements IDebugRequestHandler {
 
@@ -37,7 +42,7 @@ public class RefreshVariablesHandler implements IDebugRequestHandler {
             IDebugAdapterContext context) {
         RefreshVariablesArguments refreshArgs = (RefreshVariablesArguments) arguments;
         if (refreshArgs != null) {
-            DebugSettings.getCurrent().showHex = refreshArgs.showHex;
+            DebugSettings.getCurrent().formatType = getFormatType(refreshArgs.showHex, refreshArgs.formatType);
             DebugSettings.getCurrent().showQualifiedNames = refreshArgs.showQualifiedNames;
             DebugSettings.getCurrent().showStaticVariables = refreshArgs.showStaticVariables;
             DebugSettings.getCurrent().showLogicalStructure = refreshArgs.showLogicalStructure;
@@ -46,5 +51,16 @@ public class RefreshVariablesHandler implements IDebugRequestHandler {
 
         context.getProtocolServer().sendEvent(new InvalidatedEvent(InvalidatedAreas.VARIABLES));
         return CompletableFuture.completedFuture(response);
+    }
+
+    private NumericFormatEnum getFormatType(boolean showHex, String formatType) {
+        if (formatType != null) {
+            try {
+                return NumericFormatEnum.valueOf(formatType);
+            } catch (IllegalArgumentException exp) {
+                // can't parse format so just return default value;
+            }
+        }
+        return showHex ? NumericFormatEnum.HEX : NumericFormatEnum.DEC;
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetVariableRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetVariableRequestHandler.java
@@ -77,7 +77,7 @@ public class SetVariableRequestHandler implements IDebugRequestHandler {
         boolean showStaticVariables = DebugSettings.getCurrent().showStaticVariables;
         IVariableFormatter variableFormatter = context.getVariableFormatter();
         Map<String, Object> options = variableFormatter.getDefaultOptions();
-        VariableUtils.applyFormatterOptions(options, setVarArguments.format != null && setVarArguments.format.hex);
+        VariableUtils.applyFormatterOptions(options, setVarArguments.format);
 
         Object container = context.getRecyclableIdPool().getObjectById(setVarArguments.variablesReference);
         // container is null means the stack frame is continued by user manually.

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -76,7 +76,7 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
         boolean showStaticVariables = DebugSettings.getCurrent().showStaticVariables;
 
         Map<String, Object> options = variableFormatter.getDefaultOptions();
-        VariableUtils.applyFormatterOptions(options, varArgs.format != null && varArgs.format.hex);
+        VariableUtils.applyFormatterOptions(options, varArgs.format);
         IEvaluationProvider evaluationEngine = context.getProvider(IEvaluationProvider.class);
 
         List<Types.Variable> list = new ArrayList<>();

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
@@ -24,7 +24,9 @@ import com.microsoft.java.debug.core.protocol.Types.DataBreakpoint;
 public class Requests {
 
     public static class ValueFormat {
+        @Deprecated
         public boolean hex;
+        public String type;
     }
 
     public static class Arguments {
@@ -300,7 +302,9 @@ public class Requests {
     public static class RefreshVariablesArguments extends Arguments {
         public boolean showStaticVariables = false;
         public boolean showQualifiedNames = false;
+        @Deprecated
         public boolean showHex = false;
+        public String formatType = null;
         public boolean showLogicalStructure = true;
         public boolean showToString = true;
     }

--- a/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatterTest.java
+++ b/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatterTest.java
@@ -34,176 +34,186 @@ import static com.microsoft.java.debug.core.adapter.formatter.NumericFormatter.N
 import static org.junit.Assert.*;
 
 public class NumericFormatterTest extends BaseJdiTestCase {
-    protected NumericFormatter formatter;
-    @Before
-    public void setup() throws Exception {
-        super.setup();
-        formatter = new NumericFormatter();
-    }
+        protected NumericFormatter formatter;
 
-    @Test
-    public void testAcceptType() throws Exception {
-        LocalVariable i = this.getLocalVariable("i");
+        @Before
+        public void setup() throws Exception {
+                super.setup();
+                formatter = new NumericFormatter();
+        }
 
-        assertFalse("NumericFormatter should accept null.", formatter.acceptType(null, new HashMap<>()));
-        assertTrue("NumericFormatter should accept int type.", formatter.acceptType(i.type(), new HashMap<>()));
-        ObjectReference integer = this.getObjectReference("java.lang.Integer");
-        assertFalse("NumericFormatter should not accept Integer type.", formatter.acceptType(integer.type(), new HashMap<>()));
-        assertFalse("NumericFormatter should not accept Object type.", formatter.acceptType(this.getLocalVariable("obj").type(), new HashMap<>()));
-        assertFalse("NumericFormatter should not accept array type.", formatter.acceptType(this.getLocalVariable("arrays").type(), new HashMap<>()));
-        assertFalse("NumericFormatter should not accept String type.", formatter.acceptType(this.getLocalVariable("str").type(), new HashMap<>()));
+        @Test
+        public void testAcceptType() throws Exception {
+                LocalVariable i = this.getLocalVariable("i");
 
-        VirtualMachine vm = getVM();
-        assertFalse("NumericFormatter should not accept boolean type.",
-            formatter.acceptType(vm.mirrorOf(true).type(), new HashMap<>()));
+                assertFalse("NumericFormatter should accept null.", formatter.acceptType(null, new HashMap<>()));
+                assertTrue("NumericFormatter should accept int type.", formatter.acceptType(i.type(), new HashMap<>()));
+                ObjectReference integer = this.getObjectReference("java.lang.Integer");
+                assertFalse("NumericFormatter should not accept Integer type.",
+                                formatter.acceptType(integer.type(), new HashMap<>()));
+                assertFalse("NumericFormatter should not accept Object type.",
+                                formatter.acceptType(this.getLocalVariable("obj").type(), new HashMap<>()));
+                assertFalse("NumericFormatter should not accept array type.",
+                                formatter.acceptType(this.getLocalVariable("arrays").type(), new HashMap<>()));
+                assertFalse("NumericFormatter should not accept String type.",
+                                formatter.acceptType(this.getLocalVariable("str").type(), new HashMap<>()));
 
-        assertFalse("NumericFormatter should not accept char type.",
-            formatter.acceptType(vm.mirrorOf('c').type(), new HashMap<>()));
+                VirtualMachine vm = getVM();
+                assertFalse("NumericFormatter should not accept boolean type.",
+                                formatter.acceptType(vm.mirrorOf(true).type(), new HashMap<>()));
 
-        assertTrue("NumericFormatter should accept long type.",
-            formatter.acceptType(vm.mirrorOf(1L).type(), new HashMap<>()));
+                assertFalse("NumericFormatter should not accept char type.",
+                                formatter.acceptType(vm.mirrorOf('c').type(), new HashMap<>()));
 
-        assertTrue("NumericFormatter should accept float type.",
-            formatter.acceptType(vm.mirrorOf(1.2f).type(), new HashMap<>()));
+                assertTrue("NumericFormatter should accept long type.",
+                                formatter.acceptType(vm.mirrorOf(1L).type(), new HashMap<>()));
 
-        assertTrue("NumericFormatter should accept double type.",
-            formatter.acceptType(vm.mirrorOf(1.2).type(), new HashMap<>()));
+                assertTrue("NumericFormatter should accept float type.",
+                                formatter.acceptType(vm.mirrorOf(1.2f).type(), new HashMap<>()));
 
-        assertTrue("NumericFormatter should accept byte type.",
-            formatter.acceptType(vm.mirrorOf((byte)12).type(), new HashMap<>()));
+                assertTrue("NumericFormatter should accept double type.",
+                                formatter.acceptType(vm.mirrorOf(1.2).type(), new HashMap<>()));
 
-        assertTrue("NumericFormatter should accept short type.",
-            formatter.acceptType(vm.mirrorOf((short)12121).type(), new HashMap<>()));
-    }
+                assertTrue("NumericFormatter should accept byte type.",
+                                formatter.acceptType(vm.mirrorOf((byte) 12).type(), new HashMap<>()));
 
-    @Test
-    public void testToString() throws Exception {
-        Value i = this.getLocalValue("i");
-        assertEquals("NumericFormatter should be able to format int correctly.", "111", formatter.toString(i, new HashMap<>()));
+                assertTrue("NumericFormatter should accept short type.",
+                                formatter.acceptType(vm.mirrorOf((short) 12121).type(), new HashMap<>()));
+        }
 
+        @Test
+        public void testToString() throws Exception {
+                Value i = this.getLocalValue("i");
+                assertEquals("NumericFormatter should be able to format int correctly.", "111",
+                                formatter.toString(i, new HashMap<>()));
 
-        VirtualMachine vm = getVM();
+                VirtualMachine vm = getVM();
 
-        assertEquals("NumericFormatter should be able to format double correctly.", "111.000000",
-            formatter.toString(vm.mirrorOf(111.0), new HashMap<>()));
-        assertEquals("NumericFormatter should be able to format float correctly.", "111.000000",
-            formatter.toString(vm.mirrorOf(111.0f), new HashMap<>()));
+                assertEquals("NumericFormatter should be able to format double correctly.", "111.000000",
+                                formatter.toString(vm.mirrorOf(111.0), new HashMap<>()));
+                assertEquals("NumericFormatter should be able to format float correctly.", "111.000000",
+                                formatter.toString(vm.mirrorOf(111.0f), new HashMap<>()));
 
-        Map<String, Object> options = formatter.getDefaultOptions();
-        options.put(NUMERIC_PRECISION_OPTION, 1);
-        assertEquals("NumericFormatter should be able to format double correctly.", "111.0",
-            formatter.toString(vm.mirrorOf(111.0), options));
-        assertEquals("NumericFormatter should be able to format float correctly.", "111.0",
-            formatter.toString(vm.mirrorOf(111.0f), options));
+                Map<String, Object> options = formatter.getDefaultOptions();
+                options.put(NUMERIC_PRECISION_OPTION, 1);
+                assertEquals("NumericFormatter should be able to format double correctly.", "111.0",
+                                formatter.toString(vm.mirrorOf(111.0), options));
+                assertEquals("NumericFormatter should be able to format float correctly.", "111.0",
+                                formatter.toString(vm.mirrorOf(111.0f), options));
 
-        options.put(NUMERIC_PRECISION_OPTION, -1);
-        assertEquals("NumericFormatter should be able to format double correctly.", "111.000000",
-            formatter.toString(vm.mirrorOf(111.0), options));
-    }
+                options.put(NUMERIC_PRECISION_OPTION, -1);
+                assertEquals("NumericFormatter should be able to format double correctly.", "111.000000",
+                                formatter.toString(vm.mirrorOf(111.0), options));
+        }
 
-    @Test
-    public void testToHexOctString() throws Exception {
-        Value i = this.getLocalValue("i");
+        @Test
+        public void testToHexOctBinString() throws Exception {
+                Value i = this.getLocalValue("i");
 
-        Map<String, Object> options = formatter.getDefaultOptions();
-        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
-        assertEquals("NumericFormatter should be able to format an hex integer.",
-            "0x" + Integer.toHexString(111), formatter.toString(i, options));
+                Map<String, Object> options = formatter.getDefaultOptions();
+                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
+                assertEquals("NumericFormatter should be able to format an hex integer.",
+                                "0x" + Integer.toHexString(111), formatter.toString(i, options));
 
+                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
+                assertEquals("NumericFormatter should be able to format an oct integer.",
+                                "0" + Integer.toOctalString(111), formatter.toString(i, options));
 
-        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
-        assertEquals("NumericFormatter should be able to format an oct integer.",
-            "0" +Integer.toOctalString(111), formatter.toString(i, options));
-    }
+                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.BIN);
+                assertEquals("NumericFormatter should be able to format an bin integer.",
+                                "0b" + Integer.toBinaryString(111), formatter.toString(i, options));
+        }
 
-    @Test
-    public void testValueOf() throws Exception {
+        @Test
+        public void testValueOf() throws Exception {
 
-        Value i = this.getLocalValue("i");
-        Map<String, Object> options = formatter.getDefaultOptions();
-        Value newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
-        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-        assertEquals("Should create an integer with right value.", "111", newValue.toString());
+                Value i = this.getLocalValue("i");
+                Map<String, Object> options = formatter.getDefaultOptions();
+                Value newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
+                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+                assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
-        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
+                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
+                newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
+                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+                assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
-        newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
-        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-        assertEquals("Should create an integer with right value.", "111", newValue.toString());
+                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
+                newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
+                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+                assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
-        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
-        newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
-        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-        assertEquals("Should create an integer with right value.", "111", newValue.toString());
+                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.BIN);
+                newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
+                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+                assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
+                newValue = formatter.valueOf("-12121212", i.type(), options);
+                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+                assertEquals("Should create an integer with right value.", "-12121212", newValue.toString());
 
-        newValue = formatter.valueOf("-12121212", i.type(), options);
-        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-        assertEquals("Should create an integer with right value.", "-12121212", newValue.toString());
+                newValue = formatter.valueOf("0", i.type(), options);
+                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+                assertEquals("Should create an integer with right value.", "0", newValue.toString());
 
-        newValue = formatter.valueOf("0", i.type(), options);
-        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-        assertEquals("Should create an integer with right value.", "0", newValue.toString());
+                VirtualMachine vm = getVM();
 
-        VirtualMachine vm = getVM();
+                newValue = formatter.valueOf("0", vm.mirrorOf(10.0f).type(), options);
+                assertNotNull("NumericFormatter should be able to create float by string.", newValue);
+                assertTrue("Should create an float value.", newValue instanceof FloatValue);
+                assertEquals("Should create an float with right value.", "0.0", newValue.toString());
 
-        newValue = formatter.valueOf("0", vm.mirrorOf(10.0f).type(), options);
-        assertNotNull("NumericFormatter should be able to create float by string.", newValue);
-        assertTrue("Should create an float value.", newValue instanceof FloatValue);
-        assertEquals("Should create an float with right value.", "0.0", newValue.toString());
+                newValue = formatter.valueOf("10.0", vm.mirrorOf(10.0).type(), options);
+                assertNotNull("NumericFormatter should be able to create double by string.", newValue);
+                assertTrue("Should create an double value.", newValue instanceof DoubleValue);
+                assertEquals("Should create an double with right value.", "10.0", newValue.toString());
 
-        newValue = formatter.valueOf("10.0", vm.mirrorOf(10.0).type(), options);
-        assertNotNull("NumericFormatter should be able to create double by string.", newValue);
-        assertTrue("Should create an double value.", newValue instanceof DoubleValue);
-        assertEquals("Should create an double with right value.", "10.0", newValue.toString());
+                newValue = formatter.valueOf("10", vm.mirrorOf((short) 10).type(), options);
+                assertNotNull("NumericFormatter should be able to create short by string.", newValue);
+                assertTrue("Should create an short value.", newValue instanceof ShortValue);
+                assertEquals("Should create an short with right value.", "10", newValue.toString());
 
-        newValue = formatter.valueOf("10", vm.mirrorOf((short)10).type(), options);
-        assertNotNull("NumericFormatter should be able to create short by string.", newValue);
-        assertTrue("Should create an short value.", newValue instanceof ShortValue);
-        assertEquals("Should create an short with right value.", "10", newValue.toString());
+                newValue = formatter.valueOf("10", vm.mirrorOf(10L).type(), options);
+                assertNotNull("NumericFormatter should be able to create long by string.", newValue);
+                assertTrue("Should create an long value.", newValue instanceof LongValue);
+                assertEquals("Should create an long with right value.", "10", newValue.toString());
 
-        newValue = formatter.valueOf("10", vm.mirrorOf(10L).type(), options);
-        assertNotNull("NumericFormatter should be able to create long by string.", newValue);
-        assertTrue("Should create an long value.", newValue instanceof LongValue);
-        assertEquals("Should create an long with right value.", "10", newValue.toString());
+                newValue = formatter.valueOf("10", vm.mirrorOf((byte) 10).type(), options);
+                assertNotNull("NumericFormatter should be able to create byte by string.", newValue);
+                assertTrue("Should create an byte value.", newValue instanceof ByteValue);
+                assertEquals("Should create an byte with right value.", "10", newValue.toString());
+        }
 
-        newValue = formatter.valueOf("10", vm.mirrorOf((byte) 10).type(), options);
-        assertNotNull("NumericFormatter should be able to create byte by string.", newValue);
-        assertTrue("Should create an byte value.", newValue instanceof ByteValue);
-        assertEquals("Should create an byte with right value.", "10", newValue.toString());
-    }
+        @Test(expected = UnsupportedOperationException.class)
+        public void testValueOfNotSupported() {
+                ObjectReference or = this.getObjectReference("Foo");
+                formatter.valueOf("new Foo()", or.referenceType(), new HashMap<>());
+                fail("Set value for object is not supported.");
+        }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testValueOfNotSupported() {
-        ObjectReference or = this.getObjectReference("Foo");
-        formatter.valueOf("new Foo()", or.referenceType(), new HashMap<>());
-        fail("Set value for object is not supported.");
-    }
+        @Test(expected = NumberFormatException.class)
+        public void testValueOfNotIllegalInput() {
+                formatter.valueOf("new Foo()", getVM().mirrorOf(10.0).type(), new HashMap<>());
+                fail("Set value for object is not supported.");
+        }
 
+        @Test(expected = UnsupportedOperationException.class)
+        public void testToStringNotSupported() {
+                ObjectReference or = this.getObjectReference("Foo");
+                formatter.toString(or, new HashMap<>());
+                fail("format object should not be supported by numeric formatter.");
+        }
 
-    @Test(expected = NumberFormatException.class)
-    public void testValueOfNotIllegalInput() {
-        formatter.valueOf("new Foo()", getVM().mirrorOf(10.0).type(), new HashMap<>());
-        fail("Set value for object is not supported.");
-    }
-
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testToStringNotSupported() {
-        ObjectReference or = this.getObjectReference("Foo");
-        formatter.toString(or, new HashMap<>());
-        fail("format object should not be supported by numeric formatter.");
-    }
-
-    @Test
-    public void testDefaultOptions() {
-        Map<String, Object> options = formatter.getDefaultOptions();
-        assertNotNull("Default options should never be null.", options);
-        assertEquals("Default options for numeric formatter should have two options.", 2, options.size());
-    }
+        @Test
+        public void testDefaultOptions() {
+                Map<String, Object> options = formatter.getDefaultOptions();
+                assertNotNull("Default options should never be null.", options);
+                assertEquals("Default options for numeric formatter should have two options.", 2, options.size());
+        }
 }

--- a/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatterTest.java
+++ b/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatterTest.java
@@ -34,186 +34,176 @@ import static com.microsoft.java.debug.core.adapter.formatter.NumericFormatter.N
 import static org.junit.Assert.*;
 
 public class NumericFormatterTest extends BaseJdiTestCase {
-        protected NumericFormatter formatter;
+    protected NumericFormatter formatter;
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        formatter = new NumericFormatter();
+    }
 
-        @Before
-        public void setup() throws Exception {
-                super.setup();
-                formatter = new NumericFormatter();
-        }
+    @Test
+    public void testAcceptType() throws Exception {
+        LocalVariable i = this.getLocalVariable("i");
 
-        @Test
-        public void testAcceptType() throws Exception {
-                LocalVariable i = this.getLocalVariable("i");
+        assertFalse("NumericFormatter should accept null.", formatter.acceptType(null, new HashMap<>()));
+        assertTrue("NumericFormatter should accept int type.", formatter.acceptType(i.type(), new HashMap<>()));
+        ObjectReference integer = this.getObjectReference("java.lang.Integer");
+        assertFalse("NumericFormatter should not accept Integer type.", formatter.acceptType(integer.type(), new HashMap<>()));
+        assertFalse("NumericFormatter should not accept Object type.", formatter.acceptType(this.getLocalVariable("obj").type(), new HashMap<>()));
+        assertFalse("NumericFormatter should not accept array type.", formatter.acceptType(this.getLocalVariable("arrays").type(), new HashMap<>()));
+        assertFalse("NumericFormatter should not accept String type.", formatter.acceptType(this.getLocalVariable("str").type(), new HashMap<>()));
 
-                assertFalse("NumericFormatter should accept null.", formatter.acceptType(null, new HashMap<>()));
-                assertTrue("NumericFormatter should accept int type.", formatter.acceptType(i.type(), new HashMap<>()));
-                ObjectReference integer = this.getObjectReference("java.lang.Integer");
-                assertFalse("NumericFormatter should not accept Integer type.",
-                                formatter.acceptType(integer.type(), new HashMap<>()));
-                assertFalse("NumericFormatter should not accept Object type.",
-                                formatter.acceptType(this.getLocalVariable("obj").type(), new HashMap<>()));
-                assertFalse("NumericFormatter should not accept array type.",
-                                formatter.acceptType(this.getLocalVariable("arrays").type(), new HashMap<>()));
-                assertFalse("NumericFormatter should not accept String type.",
-                                formatter.acceptType(this.getLocalVariable("str").type(), new HashMap<>()));
+        VirtualMachine vm = getVM();
+        assertFalse("NumericFormatter should not accept boolean type.",
+            formatter.acceptType(vm.mirrorOf(true).type(), new HashMap<>()));
 
-                VirtualMachine vm = getVM();
-                assertFalse("NumericFormatter should not accept boolean type.",
-                                formatter.acceptType(vm.mirrorOf(true).type(), new HashMap<>()));
+        assertFalse("NumericFormatter should not accept char type.",
+            formatter.acceptType(vm.mirrorOf('c').type(), new HashMap<>()));
 
-                assertFalse("NumericFormatter should not accept char type.",
-                                formatter.acceptType(vm.mirrorOf('c').type(), new HashMap<>()));
+        assertTrue("NumericFormatter should accept long type.",
+            formatter.acceptType(vm.mirrorOf(1L).type(), new HashMap<>()));
 
-                assertTrue("NumericFormatter should accept long type.",
-                                formatter.acceptType(vm.mirrorOf(1L).type(), new HashMap<>()));
+        assertTrue("NumericFormatter should accept float type.",
+            formatter.acceptType(vm.mirrorOf(1.2f).type(), new HashMap<>()));
 
-                assertTrue("NumericFormatter should accept float type.",
-                                formatter.acceptType(vm.mirrorOf(1.2f).type(), new HashMap<>()));
+        assertTrue("NumericFormatter should accept double type.",
+            formatter.acceptType(vm.mirrorOf(1.2).type(), new HashMap<>()));
 
-                assertTrue("NumericFormatter should accept double type.",
-                                formatter.acceptType(vm.mirrorOf(1.2).type(), new HashMap<>()));
+        assertTrue("NumericFormatter should accept byte type.",
+            formatter.acceptType(vm.mirrorOf((byte)12).type(), new HashMap<>()));
 
-                assertTrue("NumericFormatter should accept byte type.",
-                                formatter.acceptType(vm.mirrorOf((byte) 12).type(), new HashMap<>()));
+        assertTrue("NumericFormatter should accept short type.",
+            formatter.acceptType(vm.mirrorOf((short)12121).type(), new HashMap<>()));
+    }
 
-                assertTrue("NumericFormatter should accept short type.",
-                                formatter.acceptType(vm.mirrorOf((short) 12121).type(), new HashMap<>()));
-        }
+    @Test
+    public void testToString() throws Exception {
+        Value i = this.getLocalValue("i");
+        assertEquals("NumericFormatter should be able to format int correctly.", "111", formatter.toString(i, new HashMap<>()));
 
-        @Test
-        public void testToString() throws Exception {
-                Value i = this.getLocalValue("i");
-                assertEquals("NumericFormatter should be able to format int correctly.", "111",
-                                formatter.toString(i, new HashMap<>()));
 
-                VirtualMachine vm = getVM();
+        VirtualMachine vm = getVM();
 
-                assertEquals("NumericFormatter should be able to format double correctly.", "111.000000",
-                                formatter.toString(vm.mirrorOf(111.0), new HashMap<>()));
-                assertEquals("NumericFormatter should be able to format float correctly.", "111.000000",
-                                formatter.toString(vm.mirrorOf(111.0f), new HashMap<>()));
+        assertEquals("NumericFormatter should be able to format double correctly.", "111.000000",
+            formatter.toString(vm.mirrorOf(111.0), new HashMap<>()));
+        assertEquals("NumericFormatter should be able to format float correctly.", "111.000000",
+            formatter.toString(vm.mirrorOf(111.0f), new HashMap<>()));
 
-                Map<String, Object> options = formatter.getDefaultOptions();
-                options.put(NUMERIC_PRECISION_OPTION, 1);
-                assertEquals("NumericFormatter should be able to format double correctly.", "111.0",
-                                formatter.toString(vm.mirrorOf(111.0), options));
-                assertEquals("NumericFormatter should be able to format float correctly.", "111.0",
-                                formatter.toString(vm.mirrorOf(111.0f), options));
+        Map<String, Object> options = formatter.getDefaultOptions();
+        options.put(NUMERIC_PRECISION_OPTION, 1);
+        assertEquals("NumericFormatter should be able to format double correctly.", "111.0",
+            formatter.toString(vm.mirrorOf(111.0), options));
+        assertEquals("NumericFormatter should be able to format float correctly.", "111.0",
+            formatter.toString(vm.mirrorOf(111.0f), options));
 
-                options.put(NUMERIC_PRECISION_OPTION, -1);
-                assertEquals("NumericFormatter should be able to format double correctly.", "111.000000",
-                                formatter.toString(vm.mirrorOf(111.0), options));
-        }
+        options.put(NUMERIC_PRECISION_OPTION, -1);
+        assertEquals("NumericFormatter should be able to format double correctly.", "111.000000",
+            formatter.toString(vm.mirrorOf(111.0), options));
+    }
 
-        @Test
-        public void testToHexOctBinString() throws Exception {
-                Value i = this.getLocalValue("i");
+    @Test
+    public void testToHexOctString() throws Exception {
+        Value i = this.getLocalValue("i");
 
-                Map<String, Object> options = formatter.getDefaultOptions();
-                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
-                assertEquals("NumericFormatter should be able to format an hex integer.",
-                                "0x" + Integer.toHexString(111), formatter.toString(i, options));
+        Map<String, Object> options = formatter.getDefaultOptions();
+        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
+        assertEquals("NumericFormatter should be able to format an hex integer.",
+            "0x" + Integer.toHexString(111), formatter.toString(i, options));
 
-                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
-                assertEquals("NumericFormatter should be able to format an oct integer.",
-                                "0" + Integer.toOctalString(111), formatter.toString(i, options));
 
-                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.BIN);
-                assertEquals("NumericFormatter should be able to format an bin integer.",
-                                "0b" + Integer.toBinaryString(111), formatter.toString(i, options));
-        }
+        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
+        assertEquals("NumericFormatter should be able to format an oct integer.",
+            "0" +Integer.toOctalString(111), formatter.toString(i, options));
+    }
 
-        @Test
-        public void testValueOf() throws Exception {
+    @Test
+    public void testValueOf() throws Exception {
 
-                Value i = this.getLocalValue("i");
-                Map<String, Object> options = formatter.getDefaultOptions();
-                Value newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
-                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-                assertEquals("Should create an integer with right value.", "111", newValue.toString());
+        Value i = this.getLocalValue("i");
+        Map<String, Object> options = formatter.getDefaultOptions();
+        Value newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
+        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+        assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
-                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
-                newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
-                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-                assertEquals("Should create an integer with right value.", "111", newValue.toString());
+        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
 
-                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
-                newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
-                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-                assertEquals("Should create an integer with right value.", "111", newValue.toString());
+        newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
+        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+        assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
-                options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.BIN);
-                newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
-                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-                assertEquals("Should create an integer with right value.", "111", newValue.toString());
+        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
+        newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
+        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+        assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
-                newValue = formatter.valueOf("-12121212", i.type(), options);
-                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-                assertEquals("Should create an integer with right value.", "-12121212", newValue.toString());
 
-                newValue = formatter.valueOf("0", i.type(), options);
-                assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
-                assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
-                assertEquals("Should create an integer with right value.", "0", newValue.toString());
+        newValue = formatter.valueOf("-12121212", i.type(), options);
+        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+        assertEquals("Should create an integer with right value.", "-12121212", newValue.toString());
 
-                VirtualMachine vm = getVM();
+        newValue = formatter.valueOf("0", i.type(), options);
+        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+        assertEquals("Should create an integer with right value.", "0", newValue.toString());
 
-                newValue = formatter.valueOf("0", vm.mirrorOf(10.0f).type(), options);
-                assertNotNull("NumericFormatter should be able to create float by string.", newValue);
-                assertTrue("Should create an float value.", newValue instanceof FloatValue);
-                assertEquals("Should create an float with right value.", "0.0", newValue.toString());
+        VirtualMachine vm = getVM();
 
-                newValue = formatter.valueOf("10.0", vm.mirrorOf(10.0).type(), options);
-                assertNotNull("NumericFormatter should be able to create double by string.", newValue);
-                assertTrue("Should create an double value.", newValue instanceof DoubleValue);
-                assertEquals("Should create an double with right value.", "10.0", newValue.toString());
+        newValue = formatter.valueOf("0", vm.mirrorOf(10.0f).type(), options);
+        assertNotNull("NumericFormatter should be able to create float by string.", newValue);
+        assertTrue("Should create an float value.", newValue instanceof FloatValue);
+        assertEquals("Should create an float with right value.", "0.0", newValue.toString());
 
-                newValue = formatter.valueOf("10", vm.mirrorOf((short) 10).type(), options);
-                assertNotNull("NumericFormatter should be able to create short by string.", newValue);
-                assertTrue("Should create an short value.", newValue instanceof ShortValue);
-                assertEquals("Should create an short with right value.", "10", newValue.toString());
+        newValue = formatter.valueOf("10.0", vm.mirrorOf(10.0).type(), options);
+        assertNotNull("NumericFormatter should be able to create double by string.", newValue);
+        assertTrue("Should create an double value.", newValue instanceof DoubleValue);
+        assertEquals("Should create an double with right value.", "10.0", newValue.toString());
 
-                newValue = formatter.valueOf("10", vm.mirrorOf(10L).type(), options);
-                assertNotNull("NumericFormatter should be able to create long by string.", newValue);
-                assertTrue("Should create an long value.", newValue instanceof LongValue);
-                assertEquals("Should create an long with right value.", "10", newValue.toString());
+        newValue = formatter.valueOf("10", vm.mirrorOf((short)10).type(), options);
+        assertNotNull("NumericFormatter should be able to create short by string.", newValue);
+        assertTrue("Should create an short value.", newValue instanceof ShortValue);
+        assertEquals("Should create an short with right value.", "10", newValue.toString());
 
-                newValue = formatter.valueOf("10", vm.mirrorOf((byte) 10).type(), options);
-                assertNotNull("NumericFormatter should be able to create byte by string.", newValue);
-                assertTrue("Should create an byte value.", newValue instanceof ByteValue);
-                assertEquals("Should create an byte with right value.", "10", newValue.toString());
-        }
+        newValue = formatter.valueOf("10", vm.mirrorOf(10L).type(), options);
+        assertNotNull("NumericFormatter should be able to create long by string.", newValue);
+        assertTrue("Should create an long value.", newValue instanceof LongValue);
+        assertEquals("Should create an long with right value.", "10", newValue.toString());
 
-        @Test(expected = UnsupportedOperationException.class)
-        public void testValueOfNotSupported() {
-                ObjectReference or = this.getObjectReference("Foo");
-                formatter.valueOf("new Foo()", or.referenceType(), new HashMap<>());
-                fail("Set value for object is not supported.");
-        }
+        newValue = formatter.valueOf("10", vm.mirrorOf((byte) 10).type(), options);
+        assertNotNull("NumericFormatter should be able to create byte by string.", newValue);
+        assertTrue("Should create an byte value.", newValue instanceof ByteValue);
+        assertEquals("Should create an byte with right value.", "10", newValue.toString());
+    }
 
-        @Test(expected = NumberFormatException.class)
-        public void testValueOfNotIllegalInput() {
-                formatter.valueOf("new Foo()", getVM().mirrorOf(10.0).type(), new HashMap<>());
-                fail("Set value for object is not supported.");
-        }
+    @Test(expected = UnsupportedOperationException.class)
+    public void testValueOfNotSupported() {
+        ObjectReference or = this.getObjectReference("Foo");
+        formatter.valueOf("new Foo()", or.referenceType(), new HashMap<>());
+        fail("Set value for object is not supported.");
+    }
 
-        @Test(expected = UnsupportedOperationException.class)
-        public void testToStringNotSupported() {
-                ObjectReference or = this.getObjectReference("Foo");
-                formatter.toString(or, new HashMap<>());
-                fail("format object should not be supported by numeric formatter.");
-        }
 
-        @Test
-        public void testDefaultOptions() {
-                Map<String, Object> options = formatter.getDefaultOptions();
-                assertNotNull("Default options should never be null.", options);
-                assertEquals("Default options for numeric formatter should have two options.", 2, options.size());
-        }
+    @Test(expected = NumberFormatException.class)
+    public void testValueOfNotIllegalInput() {
+        formatter.valueOf("new Foo()", getVM().mirrorOf(10.0).type(), new HashMap<>());
+        fail("Set value for object is not supported.");
+    }
+
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testToStringNotSupported() {
+        ObjectReference or = this.getObjectReference("Foo");
+        formatter.toString(or, new HashMap<>());
+        fail("format object should not be supported by numeric formatter.");
+    }
+
+    @Test
+    public void testDefaultOptions() {
+        Map<String, Object> options = formatter.getDefaultOptions();
+        assertNotNull("Default options should never be null.", options);
+        assertEquals("Default options for numeric formatter should have two options.", 2, options.size());
+    }
 }

--- a/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatterTest.java
+++ b/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatterTest.java
@@ -102,7 +102,7 @@ public class NumericFormatterTest extends BaseJdiTestCase {
     }
 
     @Test
-    public void testToHexOctString() throws Exception {
+    public void testToHexOctBinString() throws Exception {
         Value i = this.getLocalValue("i");
 
         Map<String, Object> options = formatter.getDefaultOptions();
@@ -113,7 +113,11 @@ public class NumericFormatterTest extends BaseJdiTestCase {
 
         options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
         assertEquals("NumericFormatter should be able to format an oct integer.",
-            "0" +Integer.toOctalString(111), formatter.toString(i, options));
+            "0" + Integer.toOctalString(111), formatter.toString(i, options));
+
+        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.BIN);
+        assertEquals("NumericFormatter should be able to format an bin integer.",
+            "0b" + Integer.toBinaryString(111), formatter.toString(i, options));
     }
 
     @Test
@@ -127,13 +131,18 @@ public class NumericFormatterTest extends BaseJdiTestCase {
         assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
         options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.HEX);
-
         newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
         assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
         assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
         assertEquals("Should create an integer with right value.", "111", newValue.toString());
 
         options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.OCT);
+        newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
+        assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
+        assertTrue("Should create an integer value.", newValue instanceof IntegerValue);
+        assertEquals("Should create an integer with right value.", "111", newValue.toString());
+
+        options.put(NUMERIC_FORMAT_OPTION, NumericFormatEnum.BIN);
         newValue = formatter.valueOf(formatter.toString(i, options), i.type(), options);
         assertNotNull("NumericFormatter should be able to create integer by string.", newValue);
         assertTrue("Should create an integer value.", newValue instanceof IntegerValue);


### PR DESCRIPTION
Hi there!
This is PR for allow represent variables in binary forma. 
I think it may be helpful for vscode-java-debug issue [#1078](https://github.com/microsoft/vscode-java-debug/issues/1078)
I've added new protocol parameter 'formatType' should contains variable format such as [BIN, OCT, HEX, DEC].
I've remain "showHex" for backward compatibility and can be delete later when PR to vscode-java-debug will be merged.
If you are not interested in this changes fill free to close this PR :)