### PR TITLE
Perf: support sending JDWP commands asynchronously

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/AsyncJdwpUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/AsyncJdwpUtils.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+* Copyright (c) 2022 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package com.microsoft.java.debug.core;
+
+import static java.util.concurrent.CompletableFuture.allOf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+public class AsyncJdwpUtils {
+    /**
+     * Create a the thread pool to process JDWP tasks.
+     * JDWP tasks are IO-bounded, so use a relatively large thread pool for JDWP tasks.
+     */
+    public static ExecutorService jdwpThreadPool = Executors.newWorkStealingPool(100);
+    // public static ExecutorService jdwpThreadPool = Executors.newCachedThreadPool();
+
+    public static CompletableFuture<Void> runAsync(List<Runnable> tasks) {
+        return runAsync(jdwpThreadPool, tasks.toArray(new Runnable[0]));
+    }
+
+    public static CompletableFuture<Void> runAsync(Runnable... tasks) {
+        return runAsync(jdwpThreadPool, tasks);
+    }
+
+    public static CompletableFuture<Void> runAsync(Executor executor, List<Runnable> tasks) {
+        return runAsync(executor, tasks.toArray(new Runnable[0]));
+    }
+
+    public static CompletableFuture<Void> runAsync(Executor executor, Runnable... tasks) {
+        List<CompletableFuture<Void>> promises = new ArrayList<>();
+        for (Runnable task : tasks) {
+            if (task == null) {
+                continue;
+            }
+
+            promises.add(CompletableFuture.runAsync(task, executor));
+        }
+
+        return CompletableFuture.allOf(promises.toArray(new CompletableFuture[0]));
+    }
+
+    public static <U> CompletableFuture<U> supplyAsync(Supplier<U> supplier) {
+        return supplyAsync(jdwpThreadPool, supplier);
+    }
+
+    public static <U> CompletableFuture<U> supplyAsync(Executor executor, Supplier<U> supplier) {
+        return CompletableFuture.supplyAsync(supplier, executor);
+    }
+
+    public static <U> U await(CompletableFuture<U> future) {
+        try {
+            return future.join();
+        } catch (CompletionException ex) {
+            if (ex.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) ex.getCause();
+            }
+
+            throw ex;
+        }
+    }
+
+    public static <U> List<U> await(CompletableFuture<U>[] futures) {
+        List<U> results = new ArrayList<>();
+        try {
+            allOf(futures).join();
+            for (CompletableFuture<U> future : futures) {
+                results.add(await(future));
+            }
+        } catch (CompletionException ex) {
+            if (ex.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) ex.getCause();
+            }
+
+            throw ex;
+        }
+
+        return results;
+    }
+
+    public static <U> List<U> await(List<CompletableFuture<U>> futures) {
+        return await((CompletableFuture<U>[]) futures.toArray(new CompletableFuture[0]));
+    }
+
+    public static <U> CompletableFuture<List<U>> all(CompletableFuture<U>... futures) {
+        return allOf(futures).thenApply((res) -> {
+            List<U> results = new ArrayList<>();
+            for (CompletableFuture<U> future : futures) {
+                results.add(future.join());
+            }
+
+            return results;
+        });
+    }
+
+    public static <U> CompletableFuture<List<U>> all(List<CompletableFuture<U>> futures) {
+        return allOf(futures.toArray(new CompletableFuture[0])).thenApply((res) -> {
+            List<U> results = new ArrayList<>();
+            for (CompletableFuture<U> future : futures) {
+                results.add(future.join());
+            }
+
+            return results;
+        });
+    }
+
+    public static <U> CompletableFuture<List<U>> flatAll(CompletableFuture<List<U>>... futures) {
+        return allOf(futures).thenApply((res) -> {
+            List<U> results = new ArrayList<>();
+            for (CompletableFuture<List<U>> future : futures) {
+                results.addAll(future.join());
+            }
+
+            return results;
+        });
+    }
+
+    public static <U> CompletableFuture<List<U>> flatAll(List<CompletableFuture<List<U>>> futures) {
+        return allOf(futures.toArray(new CompletableFuture[0])).thenApply((res) -> {
+            List<U> results = new ArrayList<>();
+            for (CompletableFuture<List<U>> future : futures) {
+                results.addAll(future.join());
+            }
+
+            return results;
+        });
+    }
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
@@ -14,6 +14,7 @@ package com.microsoft.java.debug.core;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.sun.jdi.ObjectCollectedException;
 import com.sun.jdi.ThreadReference;
 import com.sun.jdi.VirtualMachine;
 import com.sun.jdi.request.EventRequest;
@@ -57,8 +58,12 @@ public class DebugSession implements IDebugSession {
          * all threads fully.
          */
         for (ThreadReference tr : DebugUtility.getAllThreadsSafely(this)) {
-            while (!tr.isCollected() && tr.suspendCount() > 1) {
-                tr.resume();
+            try {
+                while (tr.suspendCount() > 1) {
+                    tr.resume();
+                }
+            } catch (ObjectCollectedException ex) {
+                // Skipt it if the thread is garbage collected.
             }
         }
         vm.resume();

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
@@ -63,7 +63,7 @@ public class DebugSession implements IDebugSession {
                     tr.resume();
                 }
             } catch (ObjectCollectedException ex) {
-                // Skipt it if the thread is garbage collected.
+                // Skip it if the thread is garbage collected.
             }
         }
         vm.resume();

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2020 Microsoft Corporation and others.
+ * Copyright (c) 2017-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,7 @@ public final class DebugSettings {
     public boolean exceptionFiltersUpdated = false;
     public int limitOfVariablesPerJdwpRequest = 100;
     public int jdwpRequestTimeout = 3000;
+    public AsyncMode asyncJDWP = AsyncMode.OFF;
 
     public static DebugSettings getCurrent() {
         return current;
@@ -85,6 +86,15 @@ public final class DebugSettings {
         AUTO,
         @SerializedName("never")
         NEVER
+    }
+
+    public static enum AsyncMode {
+        @SerializedName("auto")
+        AUTO,
+        @SerializedName("on")
+        ON,
+        @SerializedName("off")
+        OFF
     }
 
     public static interface IDebugSettingChangeListener {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IBreakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IBreakpoint.java
@@ -44,4 +44,11 @@ public interface IBreakpoint extends IDebugResource {
     String getLogMessage();
 
     void setLogMessage(String logMessage);
+
+    default void setAsync(boolean async) {
+    }
+
+    default boolean async() {
+        return false;
+    }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IMethodBreakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IMethodBreakpoint.java
@@ -30,4 +30,11 @@ public interface IMethodBreakpoint extends IDebugResource {
     Object getProperty(Object key);
 
     void putProperty(Object key, Object value);
+
+    default void setAsync(boolean async) {
+    }
+
+    default boolean async() {
+        return false;
+    }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
@@ -190,6 +190,12 @@ public class UsageDataSession {
         }
     }
 
+    public static void recordInfo(String key, Object value) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(key, value);
+        usageDataLogger.log(Level.INFO, "session info", map);
+    }
+
     /**
      * Record counts for each user errors encountered.
      */

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017-2020 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import com.microsoft.java.debug.core.DebugSettings;
 import com.microsoft.java.debug.core.IDebugSession;
+import com.microsoft.java.debug.core.DebugSettings.AsyncMode;
 import com.microsoft.java.debug.core.adapter.variables.IVariableFormatter;
 import com.microsoft.java.debug.core.adapter.variables.VariableFormatterFactory;
 import com.microsoft.java.debug.core.protocol.IProtocolServer;
@@ -65,6 +66,7 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     private IExceptionManager exceptionManager = new ExceptionManager();
     private IBreakpointManager breakpointManager = new BreakpointManager();
     private IStepResultManager stepResultManager = new StepResultManager();
+    private ThreadCache threadCache = new ThreadCache();
 
     public DebugAdapterContext(IProtocolServer server, IProviderContext providerContext) {
         this.providerContext = providerContext;
@@ -348,5 +350,20 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     @Override
     public void setShellProcessId(long shellProcessId) {
         this.shellProcessId = shellProcessId;
+    }
+
+    @Override
+    public void setThreadCache(ThreadCache cache) {
+        this.threadCache = cache;
+    }
+
+    @Override
+    public ThreadCache getThreadCache() {
+        return this.threadCache;
+    }
+
+    @Override
+    public boolean asyncJDWP() {
+        return DebugSettings.getCurrent().asyncJDWP == AsyncMode.ON;
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
@@ -58,6 +58,8 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     private long shellProcessId = -1;
     private long processId = -1;
 
+    private boolean localDebugging = true;
+
     private IdCollection<String> sourceReferences = new IdCollection<>();
     private RecyclableObjectPool<Long, Object> recyclableIdPool = new RecyclableObjectPool<>();
     private IVariableFormatter variableFormatter = VariableFormatterFactory.createVariableFormatter();
@@ -365,5 +367,13 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     @Override
     public boolean asyncJDWP() {
         return DebugSettings.getCurrent().asyncJDWP == AsyncMode.ON;
+    }
+
+    public boolean isLocalDebugging() {
+        return localDebugging;
+    }
+
+    public void setLocalDebugging(boolean local) {
+        this.localDebugging = local;
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
@@ -136,4 +136,10 @@ public interface IDebugAdapterContext {
     void setProcessId(long processId);
 
     long getProcessId();
+
+    void setThreadCache(ThreadCache cache);
+
+    ThreadCache getThreadCache();
+
+    boolean asyncJDWP();
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
@@ -142,4 +142,8 @@ public interface IDebugAdapterContext {
     ThreadCache getThreadCache();
 
     boolean asyncJDWP();
+
+    boolean isLocalDebugging();
+
+    void setLocalDebugging(boolean local);
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IStackFrameManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IStackFrameManager.java
@@ -31,4 +31,14 @@ public interface IStackFrameManager {
      * @return all the stackframes in the specified thread
      */
     StackFrame[] reloadStackFrames(ThreadReference thread);
+
+    /**
+     * Refersh the stackframes starting from the specified depth and length.
+     *
+     * @param thread the jdi thread
+     * @param start the index of the first frame to refresh. Index 0 represents the current frame.
+     * @param length the number of frames to refersh
+     * @return the refreshed stackframes
+     */
+    StackFrame[] reloadStackFrames(ThreadReference thread, int start, int length);
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/StackFrameManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/StackFrameManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Microsoft Corporation and others.
+ * Copyright (c) 2017-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public class StackFrameManager implements IStackFrameManager {
     private Map<Long, StackFrame[]> threadStackFrameMap = Collections.synchronizedMap(new HashMap<>());
 
     @Override
-    public StackFrame getStackFrame(StackFrameReference ref) {
+    public synchronized StackFrame getStackFrame(StackFrameReference ref) {
         ThreadReference thread = ref.getThread();
         int depth = ref.getDepth();
         StackFrame[] frames = threadStackFrameMap.get(thread.uniqueID());
@@ -32,13 +32,39 @@ public class StackFrameManager implements IStackFrameManager {
     }
 
     @Override
-    public StackFrame[] reloadStackFrames(ThreadReference thread) {
+    public synchronized StackFrame[] reloadStackFrames(ThreadReference thread) {
         return threadStackFrameMap.compute(thread.uniqueID(), (key, old) -> {
             try {
-                return thread.frames().toArray(new StackFrame[0]);
+                if (old == null || old.length == 0) {
+                    return thread.frames().toArray(new StackFrame[0]);
+                } else {
+                    return thread.frames(0, old.length).toArray(new StackFrame[0]);
+                }
             } catch (IncompatibleThreadStateException e) {
                 return new StackFrame[0];
             }
         });
+    }
+
+    @Override
+    public synchronized StackFrame[] reloadStackFrames(ThreadReference thread, int start, int length) {
+        long threadId = thread.uniqueID();
+        StackFrame[] old = threadStackFrameMap.get(threadId);
+        try {
+            StackFrame[] newFrames = thread.frames(start, length).toArray(new StackFrame[0]);
+            if (old == null || (start == 0 && length == old.length)) {
+                threadStackFrameMap.put(threadId, newFrames);
+            } else {
+                int maxLength = Math.max(old.length, start + length);
+                StackFrame[] totalFrames = new StackFrame[maxLength];
+                System.arraycopy(old, 0, totalFrames, 0, old.length);
+                System.arraycopy(newFrames, 0, totalFrames, start, length);
+                threadStackFrameMap.put(threadId, totalFrames);
+            }
+
+            return newFrames;
+        } catch (IncompatibleThreadStateException | IndexOutOfBoundsException  e) {
+            return new StackFrame[0];
+        }
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/StackFrameManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/StackFrameManager.java
@@ -11,7 +11,6 @@
 
 package com.microsoft.java.debug.core.adapter;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,7 +20,7 @@ import com.sun.jdi.StackFrame;
 import com.sun.jdi.ThreadReference;
 
 public class StackFrameManager implements IStackFrameManager {
-    private Map<Long, StackFrame[]> threadStackFrameMap = Collections.synchronizedMap(new HashMap<>());
+    private Map<Long, StackFrame[]> threadStackFrameMap = new HashMap<>();
 
     @Override
     public synchronized StackFrame getStackFrame(StackFrameReference ref) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ThreadCache.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ThreadCache.java
@@ -13,16 +13,16 @@ package com.microsoft.java.debug.core.adapter;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.sun.jdi.ThreadReference;
 
 public class ThreadCache {
     private List<ThreadReference> allThreads = new ArrayList<>();
-    private Map<Long, String> threadNameMap = Collections.synchronizedMap(new HashMap<>());
+    private Map<Long, String> threadNameMap = new ConcurrentHashMap<>();
     private Map<Long, Boolean> deathThreads = Collections.synchronizedMap(new LinkedHashMap<>() {
         @Override
         protected boolean removeEldestEntry(java.util.Map.Entry<Long, Boolean> eldest) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ThreadCache.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ThreadCache.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+* Copyright (c) 2022 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package com.microsoft.java.debug.core.adapter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.sun.jdi.ThreadReference;
+
+public class ThreadCache {
+    private List<ThreadReference> allThreads = new ArrayList<>();
+    private Map<Long, String> threadNameMap = Collections.synchronizedMap(new HashMap<>());
+    private Map<Long, Boolean> deathThreads = Collections.synchronizedMap(new LinkedHashMap<>() {
+        @Override
+        protected boolean removeEldestEntry(java.util.Map.Entry<Long, Boolean> eldest) {
+            return this.size() > 100;
+        }
+    });
+
+    public synchronized void resetThreads(List<ThreadReference> threads) {
+        allThreads.clear();
+        allThreads.addAll(threads);
+    }
+
+    public synchronized List<ThreadReference> getThreads() {
+        return allThreads;
+    }
+
+    public synchronized ThreadReference getThread(long threadId) {
+        for (ThreadReference thread : allThreads) {
+            if (threadId == thread.uniqueID()) {
+                return thread;
+            }
+        }
+
+        return null;
+    }
+
+    public void setThreadName(long threadId, String name) {
+        threadNameMap.put(threadId, name);
+    }
+
+    public String getThreadName(long threadId) {
+        return threadNameMap.get(threadId);
+    }
+
+    public void addDeathThread(long threadId) {
+        threadNameMap.remove(threadId);
+        deathThreads.put(threadId, true);
+    }
+
+    public void removeDeathThread(long threadId) {
+        deathThreads.remove(threadId);
+    }
+
+    public boolean isDeathThread(long threadId) {
+        return deathThreads.containsKey(threadId);
+    }
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugUtility;
 import com.microsoft.java.debug.core.IDebugSession;
+import com.microsoft.java.debug.core.UsageDataSession;
 import com.microsoft.java.debug.core.adapter.AdapterUtils;
 import com.microsoft.java.debug.core.adapter.Constants;
 import com.microsoft.java.debug.core.adapter.ErrorCode;
@@ -39,6 +40,7 @@ import com.microsoft.java.debug.core.protocol.Requests.Arguments;
 import com.microsoft.java.debug.core.protocol.Requests.AttachArguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 import com.sun.jdi.connect.IllegalConnectorArgumentsException;
+import com.sun.jdi.request.EventRequest;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -96,6 +98,14 @@ public class AttachRequestHandler implements IDebugRequestHandler {
                 logger.warning(warnMessage);
                 context.getProtocolServer().sendEvent(Events.OutputEvent.createConsoleOutput(warnMessage));
             }
+
+            EventRequest request = debugSession.getVM().eventRequestManager().createVMDeathRequest();
+            request.setSuspendPolicy(EventRequest.SUSPEND_NONE);
+            long sent = System.currentTimeMillis();
+            request.enable();
+            long received = System.currentTimeMillis();
+            logger.info("Network latency for JDWP command: " + (received - sent) + "ms");
+            UsageDataSession.recordInfo("networkLatency", (received - sent));
         }
 
         IEvaluationProvider evaluationProvider = context.getProvider(IEvaluationProvider.class);

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
@@ -60,6 +60,7 @@ public class AttachRequestHandler implements IDebugRequestHandler {
         context.setSourcePaths(attachArguments.sourcePaths);
         context.setDebuggeeEncoding(StandardCharsets.UTF_8); // Use UTF-8 as debuggee's default encoding format.
         context.setStepFilters(attachArguments.stepFilters);
+        context.setLocalDebugging(isLocalHost(attachArguments.hostName));
 
         IVirtualMachineManagerProvider vmProvider = context.getProvider(IVirtualMachineManagerProvider.class);
         vmHandler.setVmProvider(vmProvider);
@@ -119,6 +120,15 @@ public class AttachRequestHandler implements IDebugRequestHandler {
         // (e.g. SetBreakpointsRequest, SetExceptionBreakpointsRequest).
         context.getProtocolServer().sendEvent(new Events.InitializedEvent());
         return CompletableFuture.completedFuture(response);
+    }
+
+    private boolean isLocalHost(String hostName) {
+        if (hostName == null || "localhost".equals(hostName) || "127.0.0.1".equals(hostName)) {
+            return true;
+        }
+
+        // TODO: Check the host name of current computer as well.
+        return false;
     }
 
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java
@@ -55,6 +55,7 @@ public class ConfigurationDoneRequestHandler implements IDebugRequestHandler {
     public CompletableFuture<Response> handle(Command command, Arguments arguments, Response response, IDebugAdapterContext context) {
         IDebugSession debugSession = context.getDebugSession();
         vmHandler.setVmProvider(context.getProvider(IVirtualMachineManagerProvider.class));
+        UsageDataSession.recordInfo("asyncJDWP", context.asyncJDWP());
         if (debugSession != null) {
             // This is a global event handler to handle the JDI Event from Virtual Machine.
             debugSession.getEventHub().events().subscribe(debugEvent -> {
@@ -104,6 +105,7 @@ public class ConfigurationDoneRequestHandler implements IDebugRequestHandler {
             ThreadReference deathThread = ((ThreadDeathEvent) event).thread();
             Events.ThreadEvent threadDeathEvent = new Events.ThreadEvent("exited", deathThread.uniqueID());
             context.getProtocolServer().sendEvent(threadDeathEvent);
+            context.getThreadCache().addDeathThread(deathThread.uniqueID());
         } else if (event instanceof BreakpointEvent) {
             // ignore since SetBreakpointsRequestHandler has already handled
         } else if (event instanceof ExceptionEvent) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
@@ -64,6 +64,11 @@ public class EvaluateRequestHandler implements IDebugRequestHandler {
         VariableUtils.applyFormatterOptions(options, evalArguments.format != null && evalArguments.format.hex);
         String expression = evalArguments.expression;
 
+        // Async mode is supposed to be performant, then disable the advanced features like hover evaluation.
+        if (context.isAttached() && context.asyncJDWP() && "hover".equals(evalArguments.context)) {
+            return CompletableFuture.completedFuture(response);
+        }
+
         if (StringUtils.isBlank(expression)) {
             throw new CompletionException(AdapterUtils.createUserErrorDebugException(
                 "Failed to evaluate. Reason: Empty expression cannot be evaluated.",

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
@@ -65,7 +65,7 @@ public class EvaluateRequestHandler implements IDebugRequestHandler {
         String expression = evalArguments.expression;
 
         // Async mode is supposed to be performant, then disable the advanced features like hover evaluation.
-        if (context.isAttached() && context.asyncJDWP() && "hover".equals(evalArguments.context)) {
+        if (!context.isLocalDebugging() && context.asyncJDWP() && "hover".equals(evalArguments.context)) {
             return CompletableFuture.completedFuture(response);
         }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/InlineValuesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/InlineValuesRequestHandler.java
@@ -82,7 +82,7 @@ public class InlineValuesRequestHandler implements IDebugRequestHandler {
         }
 
         // Async mode is supposed to be performant, then disable the advanced features like inline values.
-        if (context.isAttached() && context.asyncJDWP()) {
+        if (!context.isLocalDebugging() && context.asyncJDWP()) {
             response.body = new Responses.InlineValuesResponse(null);
             return CompletableFuture.completedFuture(response);
         }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/InlineValuesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/InlineValuesRequestHandler.java
@@ -72,11 +72,17 @@ public class InlineValuesRequestHandler implements IDebugRequestHandler {
     public CompletableFuture<Response> handle(Command command, Arguments arguments, Response response,
             IDebugAdapterContext context) {
         InlineValuesArguments inlineValuesArgs = (InlineValuesArguments) arguments;
-        int variableCount = inlineValuesArgs == null || inlineValuesArgs.variables == null ? 0 : inlineValuesArgs.variables.length;
+        final int variableCount = inlineValuesArgs == null || inlineValuesArgs.variables == null ? 0 : inlineValuesArgs.variables.length;
         InlineVariable[] inlineVariables = inlineValuesArgs.variables;
         StackFrameReference stackFrameReference = (StackFrameReference) context.getRecyclableIdPool().getObjectById(inlineValuesArgs.frameId);
         if (stackFrameReference == null) {
             logger.log(Level.SEVERE, String.format("InlineValues failed: invalid stackframe id %d.", inlineValuesArgs.frameId));
+            response.body = new Responses.InlineValuesResponse(null);
+            return CompletableFuture.completedFuture(response);
+        }
+
+        // Async mode is supposed to be performant, then disable the advanced features like inline values.
+        if (context.isAttached() && context.asyncJDWP()) {
             response.body = new Responses.InlineValuesResponse(null);
             return CompletableFuture.completedFuture(response);
         }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
@@ -130,10 +130,11 @@ public class SetBreakpointsRequestHandler implements IDebugRequestHandler {
             IBreakpoint[] added = context.getBreakpointManager()
                                          .setBreakpoints(AdapterUtils.decodeURIComponent(sourcePath), toAdds, bpArguments.sourceModified);
             for (int i = 0; i < bpArguments.breakpoints.length; i++) {
+                added[i].setAsync(context.asyncJDWP());
                 // For newly added breakpoint, should install it to debuggee first.
                 if (toAdds[i] == added[i] && added[i].className() != null) {
                     added[i].install().thenAccept(bp -> {
-                        Events.BreakpointEvent bpEvent = new Events.BreakpointEvent("new", this.convertDebuggerBreakpointToClient(bp, context));
+                        Events.BreakpointEvent bpEvent = new Events.BreakpointEvent("changed", this.convertDebuggerBreakpointToClient(bp, context));
                         context.getProtocolServer().sendEvent(bpEvent);
                     });
                 } else if (added[i].className() != null) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetFunctionBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetFunctionBreakpointsRequestHandler.java
@@ -93,6 +93,7 @@ public class SetFunctionBreakpointsRequestHandler implements IDebugRequestHandle
                 continue;
             }
 
+            currentMethodBreakpoints[i].setAsync(context.asyncJDWP());
             // If the requested method breakpoint exists in the manager, it will reuse
             // the cached breakpoint exists object.
             // Otherwise add the requested method breakpoint to the cache.

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -374,11 +374,11 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
     }
 
     private boolean supportsLogicStructureView(IDebugAdapterContext context) {
-        return (!context.asyncJDWP() || !context.isAttached()) && DebugSettings.getCurrent().showLogicalStructure;
+        return (!context.asyncJDWP() || context.isLocalDebugging()) && DebugSettings.getCurrent().showLogicalStructure;
     }
 
     private boolean supportsToStringView(IDebugAdapterContext context) {
-        return (!context.asyncJDWP() || !context.isAttached()) && DebugSettings.getCurrent().showToString;
+        return (!context.asyncJDWP() || context.isLocalDebugging()) && DebugSettings.getCurrent().showToString;
     }
 
     private Types.Variable resolveLazyVariable(IDebugAdapterContext context, VariableProxy containerNode, IVariableFormatter variableFormatter,
@@ -456,10 +456,12 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
                 }));
             }
 
-            // JDWP Command: OR_REFERENCE_TYPE, RT_SIGNATURE
-            fetchVariableInfoFutures.add(AsyncJdwpUtils.runAsync(() -> {
-                value.type().signature();
-            }));
+            if (value instanceof ObjectReference) {
+                // JDWP Command: OR_REFERENCE_TYPE, RT_SIGNATURE
+                fetchVariableInfoFutures.add(AsyncJdwpUtils.runAsync(() -> {
+                    value.type().signature();
+                }));
+            }
         }
 
         return CompletableFuture.allOf(fetchVariableInfoFutures.toArray(new CompletableFuture[0]));

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017-2021 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -19,11 +19,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import com.microsoft.java.debug.core.AsyncJdwpUtils;
 import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugSettings;
 import com.microsoft.java.debug.core.JdiMethodResult;
@@ -39,6 +42,7 @@ import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.Logi
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalVariable;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructureManager;
 import com.microsoft.java.debug.core.adapter.variables.StackFrameReference;
+import com.microsoft.java.debug.core.adapter.variables.StringReferenceProxy;
 import com.microsoft.java.debug.core.adapter.variables.Variable;
 import com.microsoft.java.debug.core.adapter.variables.VariableDetailUtils;
 import com.microsoft.java.debug.core.adapter.variables.VariableProxy;
@@ -57,6 +61,7 @@ import com.sun.jdi.InternalException;
 import com.sun.jdi.InvalidStackFrameException;
 import com.sun.jdi.ObjectReference;
 import com.sun.jdi.StackFrame;
+import com.sun.jdi.StringReference;
 import com.sun.jdi.Type;
 import com.sun.jdi.Value;
 
@@ -96,7 +101,7 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
 
         VariableProxy containerNode = (VariableProxy) container;
 
-        if (containerNode.isLazyVariable() && DebugSettings.getCurrent().showToString) {
+        if (supportsToStringView(context) && containerNode.isLazyVariable()) {
             Types.Variable typedVariable = this.resolveLazyVariable(context, containerNode, variableFormatter, options, evaluationEngine);
             if (typedVariable != null) {
                 list.add(typedVariable);
@@ -123,24 +128,29 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
                     String returnIcon = (AdapterUtils.isWin || AdapterUtils.isMac) ? "⎯►" : "->";
                     childrenList.add(new Variable(returnIcon + result.method.name() + "()", result.value, null));
                 }
-                childrenList.addAll(VariableUtils.listLocalVariables(frame));
-                Variable thisVariable = VariableUtils.getThisVariable(frame);
-                if (thisVariable != null) {
-                    childrenList.add(thisVariable);
+
+                if (context.asyncJDWP()) {
+                    childrenList.addAll(getVariablesOfFrameAsync(frame, showStaticVariables));
+                } else {
+                    childrenList.addAll(VariableUtils.listLocalVariables(frame));
+                    Variable thisVariable = VariableUtils.getThisVariable(frame);
+                    if (thisVariable != null) {
+                        childrenList.add(thisVariable);
+                    }
+                    if (showStaticVariables && frame.location().method().isStatic()) {
+                        childrenList.addAll(VariableUtils.listStaticVariables(frame));
+                    }
                 }
-                if (showStaticVariables && frame.location().method().isStatic()) {
-                    childrenList.addAll(VariableUtils.listStaticVariables(frame));
-                }
-            } catch (AbsentInformationException | InternalException | InvalidStackFrameException e) {
+            } catch (CompletionException | InternalException | InvalidStackFrameException | CancellationException | AbsentInformationException e) {
                 throw AdapterUtils.createCompletionException(
                     String.format("Failed to get variables. Reason: %s", e.toString()),
                     ErrorCode.GET_VARIABLE_FAILURE,
-                    e);
+                    e.getCause() != null ? e.getCause() : e);
             }
         } else {
             try {
                 ObjectReference containerObj = (ObjectReference) containerNode.getProxiedVariable();
-                if (DebugSettings.getCurrent().showLogicalStructure && evaluationEngine != null) {
+                if (supportsLogicStructureView(context) && evaluationEngine != null) {
                     JavaLogicalStructure logicalStructure = null;
                     try {
                         logicalStructure = JavaLogicalStructureManager.getLogicalStructure(containerObj);
@@ -232,6 +242,17 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
                 }
             });
         }
+
+        // Since JDI caches the fetched properties locally, in async mode we can warm up the JDI cache in advance.
+        if (context.asyncJDWP()) {
+            try {
+                AsyncJdwpUtils.await(warmUpJDICache(childrenList));
+            } catch (CompletionException | CancellationException e) {
+                response.body = new Responses.VariablesResponseBody(list);
+                return CompletableFuture.completedFuture(response);
+            }
+        }
+
         for (Variable javaVariable : childrenList) {
             Value value = javaVariable.value;
             String name = javaVariable.name;
@@ -242,7 +263,7 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
             Value sizeValue = null;
             if (value instanceof ArrayReference) {
                 indexedVariables = ((ArrayReference) value).length();
-            } else if (value instanceof ObjectReference && DebugSettings.getCurrent().showLogicalStructure && evaluationEngine != null) {
+            } else if (supportsLogicStructureView(context) && value instanceof ObjectReference && evaluationEngine != null) {
                 try {
                     JavaLogicalStructure structure = JavaLogicalStructureManager.getLogicalStructure((ObjectReference) value);
                     if (structure != null && structure.getSizeExpression() != null) {
@@ -310,7 +331,7 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
                 // If failed to resolve the variable value, skip the details info as well.
             } else if (sizeValue != null) {
                 detailsValue = "size=" + variableFormatter.valueToString(sizeValue, options);
-            } else if (DebugSettings.getCurrent().showToString) {
+            } else if (supportsToStringView(context)) {
                 if (VariableDetailUtils.isLazyLoadingSupported(value) && varProxy != null) {
                     varProxy.setLazyVariable(true);
                 } else {
@@ -352,6 +373,14 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
         return CompletableFuture.completedFuture(response);
     }
 
+    private boolean supportsLogicStructureView(IDebugAdapterContext context) {
+        return (!context.asyncJDWP() || !context.isAttached()) && DebugSettings.getCurrent().showLogicalStructure;
+    }
+
+    private boolean supportsToStringView(IDebugAdapterContext context) {
+        return (!context.asyncJDWP() || !context.isAttached()) && DebugSettings.getCurrent().showToString;
+    }
+
     private Types.Variable resolveLazyVariable(IDebugAdapterContext context, VariableProxy containerNode, IVariableFormatter variableFormatter,
             Map<String, Object> options, IEvaluationProvider evaluationEngine) {
         VariableProxy valueReferenceProxy = new VariableProxy(containerNode.getThread(), containerNode.getScope(),
@@ -383,5 +412,56 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
             }
         }
         return result;
+    }
+
+    private List<Variable> getVariablesOfFrameAsync(StackFrame frame, boolean showStaticVariables) {
+        CompletableFuture<List<Variable>> localVariables = VariableUtils.listLocalVariablesAsync(frame);
+        CompletableFuture<Variable> thisVariable = VariableUtils.getThisVariableAsync(frame);
+        CompletableFuture<List<Variable>>[] staticVariables = new CompletableFuture[1];
+        if (showStaticVariables && frame.location().method().isStatic()) {
+            staticVariables[0] = VariableUtils.listStaticVariablesAsync(frame);
+        }
+
+        CompletableFuture<Void> futures = staticVariables[0] == null ? CompletableFuture.allOf(localVariables, thisVariable)
+            : CompletableFuture.allOf(localVariables, thisVariable, staticVariables[0]);
+
+        AsyncJdwpUtils.await(futures);
+
+        List<Variable> result = new ArrayList<>();
+        result.addAll(localVariables.join());
+        Variable thisVar = thisVariable.join();
+        if (thisVar != null) {
+            result.add(thisVar);
+        }
+
+        if (staticVariables[0] != null) {
+            result.addAll(staticVariables[0].join());
+        }
+
+        return result;
+    }
+
+    private CompletableFuture<Void> warmUpJDICache(List<Variable> variables) {
+        List<CompletableFuture<Void>> fetchVariableInfoFutures = new ArrayList<>();
+        for (Variable javaVariable : variables) {
+            Value value = javaVariable.value;
+            if (value instanceof ArrayReference) {
+                // JDWP Command: AR_LENGTH
+                fetchVariableInfoFutures.add(AsyncJdwpUtils.runAsync(() -> ((ArrayReference) value).length()));
+            } else if (value instanceof StringReference) {
+                // JDWP Command: SR_VALUE
+                fetchVariableInfoFutures.add(AsyncJdwpUtils.runAsync(() -> {
+                    String strValue = ((StringReference) value).value();
+                    javaVariable.value = new StringReferenceProxy((StringReference) value, strValue);
+                }));
+            }
+
+            // JDWP Command: OR_REFERENCE_TYPE, RT_SIGNATURE
+            fetchVariableInfoFutures.add(AsyncJdwpUtils.runAsync(() -> {
+                value.type().signature();
+            }));
+        }
+
+        return CompletableFuture.allOf(fetchVariableInfoFutures.toArray(new CompletableFuture[0]));
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/StringReferenceProxy.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/StringReferenceProxy.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.microsoft.java.debug.core.adapter.variables;
+
+import java.util.List;
+import java.util.Map;
+
+import com.sun.jdi.ClassNotLoadedException;
+import com.sun.jdi.Field;
+import com.sun.jdi.IncompatibleThreadStateException;
+import com.sun.jdi.InvalidTypeException;
+import com.sun.jdi.InvocationException;
+import com.sun.jdi.Method;
+import com.sun.jdi.ObjectReference;
+import com.sun.jdi.ReferenceType;
+import com.sun.jdi.StringReference;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.Type;
+import com.sun.jdi.Value;
+import com.sun.jdi.VirtualMachine;
+
+public class StringReferenceProxy implements StringReference {
+    private StringReference delegateStringRef;
+    private String value = null;
+
+    public StringReferenceProxy(StringReference sr, String value) {
+        this.delegateStringRef = sr;
+        this.value = value;
+    }
+
+    public String value() {
+        if (value != null) {
+            return value;
+        }
+
+        return delegateStringRef.value();
+    }
+
+    public ReferenceType referenceType() {
+        return delegateStringRef.referenceType();
+    }
+
+    public VirtualMachine virtualMachine() {
+        return delegateStringRef.virtualMachine();
+    }
+
+    public String toString() {
+        return delegateStringRef.toString();
+    }
+
+    public Value getValue(Field sig) {
+        return delegateStringRef.getValue(sig);
+    }
+
+    public Map<Field, Value> getValues(List<? extends Field> fields) {
+        return delegateStringRef.getValues(fields);
+    }
+
+    public void setValue(Field field, Value value) throws InvalidTypeException, ClassNotLoadedException {
+        delegateStringRef.setValue(field, value);
+    }
+
+    public Value invokeMethod(ThreadReference thread, Method method, List<? extends Value> arguments, int options)
+            throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException,
+            InvocationException {
+        return delegateStringRef.invokeMethod(thread, method, arguments, options);
+    }
+
+    public Type type() {
+        return delegateStringRef.type();
+    }
+
+    public void disableCollection() {
+        delegateStringRef.disableCollection();
+    }
+
+    public void enableCollection() {
+        delegateStringRef.enableCollection();
+    }
+
+    public boolean isCollected() {
+        return delegateStringRef.isCollected();
+    }
+
+    public long uniqueID() {
+        return delegateStringRef.uniqueID();
+    }
+
+    public List<ThreadReference> waitingThreads() throws IncompatibleThreadStateException {
+        return delegateStringRef.waitingThreads();
+    }
+
+    public ThreadReference owningThread() throws IncompatibleThreadStateException {
+        return delegateStringRef.owningThread();
+    }
+
+    public int entryCount() throws IncompatibleThreadStateException {
+        return delegateStringRef.entryCount();
+    }
+
+    public List<ObjectReference> referringObjects(long maxReferrers) {
+        return delegateStringRef.referringObjects(maxReferrers);
+    }
+
+    public boolean equals(Object obj) {
+        return delegateStringRef.equals(obj);
+    }
+
+    public int hashCode() {
+        return delegateStringRef.hashCode();
+    }
+}


### PR DESCRIPTION
This PR provides some experimental performance tuning for remote debugging:
- Add a thread cache to reduce JDWP frequency for thread info. `threads` request is the most frequent DAP request, and adding a cache can save lots of unnecessary JDWP queries.
- Provide async mode to process JDWP commands in parallel. This hopes to improve the DAP responsiveness on high-latency networks.
