### PR TITLE
Support for debugging virtual threads

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ThreadCache.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ThreadCache.java
@@ -88,6 +88,16 @@ public class ThreadCache {
         eventThreads.clear();
     }
 
+    /**
+     * The visible threads includes:
+     * 1. The currently running threads returned by the JDI API
+     * VirtualMachine.allThreads().
+     * 2. The threads suspended by events such as Breakpoint, Step, Exception etc.
+     *
+     * The part 2 is mainly for virtual threads, since VirtualMachine.allThreads()
+     * does not include virtual threads by default. For those virtual threads
+     * that are suspended, we need to show their call stacks in CALL STACK view.
+     */
     public List<ThreadReference> visibleThreads(IDebugAdapterContext context) {
         List<ThreadReference> visibleThreads = new ArrayList<>(context.getDebugSession().getAllThreads());
         Set<Long> idSet = new HashSet<>();

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017-2020 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -109,15 +109,15 @@ public class ConfigurationDoneRequestHandler implements IDebugRequestHandler {
             // ignore since SetBreakpointsRequestHandler has already handled
         } else if (event instanceof ExceptionEvent) {
             ThreadReference thread = ((ExceptionEvent) event).thread();
-            ThreadReference bpThread = ((ExceptionEvent) event).thread();
             IEvaluationProvider engine = context.getProvider(IEvaluationProvider.class);
-            if (engine.isInEvaluation(bpThread)) {
+            if (engine.isInEvaluation(thread)) {
                 return;
             }
 
             JdiExceptionReference jdiException = new JdiExceptionReference(((ExceptionEvent) event).exception(),
                     ((ExceptionEvent) event).catchLocation() == null);
             context.getExceptionManager().setException(thread.uniqueID(), jdiException);
+            context.getThreadCache().addEventThread(thread);
             context.getProtocolServer().sendEvent(new Events.StoppedEvent("exception", thread.uniqueID()));
             debugEvent.shouldResume = false;
         } else {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ExceptionInfoRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ExceptionInfoRequestHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 Microsoft Corporation and others.
+* Copyright (c) 2019-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -53,7 +53,11 @@ public class ExceptionInfoRequestHandler implements IDebugRequestHandler {
     public CompletableFuture<Response> handle(Command command, Arguments arguments, Response response,
             IDebugAdapterContext context) {
         ExceptionInfoArguments exceptionInfoArgs = (ExceptionInfoArguments) arguments;
-        ThreadReference thread = DebugUtility.getThread(context.getDebugSession(), exceptionInfoArgs.threadId);
+        ThreadReference thread = context.getThreadCache().getThread(exceptionInfoArgs.threadId);
+        if (thread == null) {
+            thread = DebugUtility.getThread(context.getDebugSession(), exceptionInfoArgs.threadId);
+        }
+
         if (thread == null) {
             throw AdapterUtils.createCompletionException("Thread " + exceptionInfoArgs.threadId + " doesn't exist.", ErrorCode.EXCEPTION_INFO_FAILURE);
         }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -207,12 +207,14 @@ public class SetBreakpointsRequestHandler implements IDebugRequestHandler {
                                 if (resume) {
                                     debugEvent.eventSet.resume();
                                 } else {
+                                    context.getThreadCache().addEventThread(bpThread);
                                     context.getProtocolServer().sendEvent(new Events.StoppedEvent(
                                             breakpointName, bpThread.uniqueID()));
                                 }
                             });
                         });
                     } else {
+                        context.getThreadCache().addEventThread(bpThread);
                         context.getProtocolServer().sendEvent(new Events.StoppedEvent(
                                 breakpointName, bpThread.uniqueID()));
                     }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetDataBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetDataBreakpointsRequestHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 Microsoft Corporation and others.
+* Copyright (c) 2019-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -151,11 +151,13 @@ public class SetDataBreakpointsRequestHandler implements IDebugRequestHandler {
                             if (resume) {
                                 debugEvent.eventSet.resume();
                             } else {
+                                context.getThreadCache().addEventThread(bpThread);
                                 context.getProtocolServer().sendEvent(new Events.StoppedEvent("data breakpoint", bpThread.uniqueID()));
                             }
                         });
                     });
                 } else {
+                    context.getThreadCache().addEventThread(bpThread);
                     context.getProtocolServer().sendEvent(new Events.StoppedEvent("data breakpoint", bpThread.uniqueID()));
                 }
                 debugEvent.shouldResume = false;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetFunctionBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetFunctionBreakpointsRequestHandler.java
@@ -165,6 +165,7 @@ public class SetFunctionBreakpointsRequestHandler implements IDebugRequestHandle
                                                 if (resume) {
                                                     debugEvent.eventSet.resume();
                                                 } else {
+                                                    context.getThreadCache().addEventThread(bpThread);
                                                     context.getProtocolServer().sendEvent(new Events.StoppedEvent(
                                                             "function breakpoint", bpThread.uniqueID()));
                                                 }
@@ -172,6 +173,7 @@ public class SetFunctionBreakpointsRequestHandler implements IDebugRequestHandle
                                 });
 
                             } else {
+                                context.getThreadCache().addEventThread(bpThread);
                                 context.getProtocolServer()
                                         .sendEvent(new Events.StoppedEvent("function breakpoint", bpThread.uniqueID()));
                             }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StepRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StepRequestHandler.java
@@ -178,6 +178,7 @@ public class StepRequestHandler implements IDebugRequestHandler {
                     threadState.pendingMethodExitRequest.enable();
                 }
 
+                context.getThreadCache().removeEventThread(thread.uniqueID());
                 DebugUtility.resumeThread(thread);
                 ThreadsRequestHandler.checkThreadRunningAndRecycleIds(thread, context);
             } catch (IncompatibleThreadStateException ex) {
@@ -255,6 +256,7 @@ public class StepRequestHandler implements IDebugRequestHandler {
             if (threadState.eventSubscription != null) {
                 threadState.eventSubscription.dispose();
             }
+            context.getThreadCache().addEventThread(thread);
             context.getProtocolServer().sendEvent(new Events.StoppedEvent("step", thread.uniqueID()));
             debugEvent.shouldResume = false;
         } else if (event instanceof MethodExitEvent) {


### PR DESCRIPTION
Address https://github.com/microsoft/vscode-java-debug/issues/1159.

What this PR does:
- For thread start and thread death events, restrict the events so they are only sent for platform threads. Since the number of virtual threads can be large, this prevents DAP from being busy with thread events.
- In the Threads view, we only list those virtual threads that are suspended by events (e.g. BreakpointEvent, StepEvent, etc.).