### PR TITLE
Fixes NumericFormatter failure on systems with other decimal separator

### DIFF
--- a/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatterTest.java
+++ b/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/adapter/formatter/NumericFormatterTest.java
@@ -29,6 +29,8 @@ import com.sun.jdi.ShortValue;
 import com.sun.jdi.Value;
 import com.sun.jdi.VirtualMachine;
 
+import java.util.Locale;
+
 import static com.microsoft.java.debug.core.adapter.formatter.NumericFormatter.NUMERIC_FORMAT_OPTION;
 import static com.microsoft.java.debug.core.adapter.formatter.NumericFormatter.NUMERIC_PRECISION_OPTION;
 import static org.junit.Assert.*;
@@ -38,6 +40,7 @@ public class NumericFormatterTest extends BaseJdiTestCase {
     @Before
     public void setup() throws Exception {
         super.setup();
+        Locale.setDefault(Locale.US);
         formatter = new NumericFormatter();
     }
 


### PR DESCRIPTION
In certain regions (e.g. Brazil, Germany, etc.), a comma is used instead of a dot as a decimal separator by default.
This change will set the default locale to US (so a dot is used as a decimal separator) before performing numeric formatter tests.

This PR fixes #337. Solution already addressed by @siqueira-gustavo (full credit goes to him), but no changes have been made. 