### PR TITLE
Visualize the inline breakpoint locations

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
@@ -115,6 +115,11 @@ public class DebugSession implements IDebugSession {
     }
 
     @Override
+    public IBreakpoint createBreakpoint(JavaBreakpointLocation sourceLocation, int hitCount, String condition, String logMessage) {
+        return new EvaluatableBreakpoint(vm, this.getEventHub(), sourceLocation, hitCount, condition, logMessage);
+    }
+
+    @Override
     public IBreakpoint createBreakpoint(String className, int lineNumber, int hitCount, String condition, String logMessage) {
         return new EvaluatableBreakpoint(vm, this.getEventHub(), className, lineNumber, hitCount, condition, logMessage);
     }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EvaluatableBreakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EvaluatableBreakpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2018 Microsoft Corporation and others.
+* Copyright (c) 2018-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -45,6 +45,12 @@ public class EvaluatableBreakpoint extends Breakpoint implements IEvaluatableBre
     EvaluatableBreakpoint(VirtualMachine vm, IEventHub eventHub, String className, int lineNumber, int hitCount,
             String condition, String logMessage) {
         super(vm, eventHub, className, lineNumber, hitCount, condition, logMessage);
+        this.eventHub = eventHub;
+    }
+
+    EvaluatableBreakpoint(VirtualMachine vm, IEventHub eventHub, JavaBreakpointLocation sourceLocation, int hitCount,
+        String condition, String logMessage) {
+        super(vm, eventHub, sourceLocation, hitCount, condition, logMessage);
         this.eventHub = eventHub;
     }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IBreakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IBreakpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -23,9 +23,13 @@ public interface IBreakpoint extends IDebugResource {
 
     int REQUEST_TYPE_LAMBDA = 2;
 
+    JavaBreakpointLocation sourceLocation();
+
     String className();
 
     int getLineNumber();
+
+    int getColumnNumber();
 
     int getHitCount();
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IDebugSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/IDebugSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -29,6 +29,8 @@ public interface IDebugSession {
 
     // breakpoints
     IBreakpoint createBreakpoint(String className, int lineNumber, int hitCount, String condition, String logMessage);
+
+    IBreakpoint createBreakpoint(JavaBreakpointLocation sourceLocation, int hitCount, String condition, String logMessage);
 
     IWatchpoint createWatchPoint(String className, String fieldName, String accessType, String condition, int hitCount);
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/JavaBreakpointLocation.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/JavaBreakpointLocation.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+* Copyright (c) 2022 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package com.microsoft.java.debug.core;
+
+import java.util.Objects;
+
+import com.microsoft.java.debug.core.protocol.Types;
+
+public class JavaBreakpointLocation {
+    /**
+     * The source line of the breakpoint or logpoint.
+     */
+    private int lineNumber;
+    /**
+     * The source column of the breakpoint.
+     */
+    private int columnNumber = -1;
+    /**
+     * The declaring class name that encloses the target position.
+     */
+    private String className;
+    /**
+     * The method name and signature when the target position
+     * points to a method declaration.
+     */
+    private String methodName;
+    private String methodSignature;
+    /**
+     * All possible locations for source breakpoints in a given range.
+     */
+    private Types.BreakpointLocation[] availableBreakpointLocations = new Types.BreakpointLocation[0];
+
+    public JavaBreakpointLocation(int lineNumber, int columnNumber) {
+        this.lineNumber = lineNumber;
+        this.columnNumber = columnNumber;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lineNumber, columnNumber, className, methodName, methodSignature);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof JavaBreakpointLocation)) {
+            return false;
+        }
+        JavaBreakpointLocation other = (JavaBreakpointLocation) obj;
+        return lineNumber == other.lineNumber && columnNumber == other.columnNumber
+                && Objects.equals(className, other.className) && Objects.equals(methodName, other.methodName)
+                && Objects.equals(methodSignature, other.methodSignature);
+    }
+
+    public int lineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    public int columnNumber() {
+        return columnNumber;
+    }
+
+    public void setColumnNumber(int columnNumber) {
+        this.columnNumber = columnNumber;
+    }
+
+    public String className() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public String methodName() {
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    public String methodSignature() {
+        return methodSignature;
+    }
+
+    public void setMethodSignature(String methodSignature) {
+        this.methodSignature = methodSignature;
+    }
+
+    public Types.BreakpointLocation[] availableBreakpointLocations() {
+        return availableBreakpointLocations;
+    }
+
+    public void setAvailableBreakpointLocations(Types.BreakpointLocation[] availableBreakpointLocations) {
+        this.availableBreakpointLocations = availableBreakpointLocations;
+    }
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/AdapterUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/AdapterUtils.java
@@ -119,13 +119,15 @@ public class AdapterUtils {
      *                              the column number from the source platform
      * @param sourceColumnsStartAt1
      *                              the source platform's column starts at 1 or not
+     * @param targetColumnStartAt1
+     *                              the target platform's column starts at 1 or not
      * @return the new column number
      */
-    public static int convertColumnNumber(int column, boolean sourceColumnsStartAt1) {
+    public static int convertColumnNumber(int column, boolean sourceColumnsStartAt1, boolean targetColumnStartAt1) {
         if (sourceColumnsStartAt1) {
-            return column - 1;
+            return targetColumnStartAt1 ? column : column - 1;
         } else {
-            return column;
+            return targetColumnStartAt1 ? column + 1 : column;
         }
     }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
@@ -21,6 +21,7 @@ import java.util.logging.Logger;
 
 import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.adapter.handler.AttachRequestHandler;
+import com.microsoft.java.debug.core.adapter.handler.BreakpointLocationsRequestHander;
 import com.microsoft.java.debug.core.adapter.handler.CompletionsHandler;
 import com.microsoft.java.debug.core.adapter.handler.ConfigurationDoneRequestHandler;
 import com.microsoft.java.debug.core.adapter.handler.DataBreakpointInfoRequestHandler;
@@ -105,7 +106,7 @@ public class DebugAdapter implements IDebugAdapter {
         registerHandler(new InitializeRequestHandler());
         registerHandler(new LaunchRequestHandler());
 
-        // DEBUG node only
+        // DEBUG mode only
         registerHandlerForDebug(new AttachRequestHandler());
         registerHandlerForDebug(new ConfigurationDoneRequestHandler());
         registerHandlerForDebug(new DisconnectRequestHandler());
@@ -129,6 +130,7 @@ public class DebugAdapter implements IDebugAdapter {
         registerHandlerForDebug(new RefreshVariablesHandler());
         registerHandlerForDebug(new ProcessIdHandler());
         registerHandlerForDebug(new SetFunctionBreakpointsRequestHandler());
+        registerHandlerForDebug(new BreakpointLocationsRequestHander());
         // NO_DEBUG mode only
         registerHandlerForNoDebug(new DisconnectRequestWithoutDebuggingHandler());
         registerHandlerForNoDebug(new ProcessIdHandler());

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
@@ -38,6 +38,8 @@ public class DebugAdapterContext implements IDebugAdapterContext {
 
     private IDebugSession debugSession;
     private boolean debuggerLinesStartAt1 = true;
+    // The Java model on debugger uses 0-based column number.
+    private boolean debuggerColumnStartAt1 = false;
     private boolean debuggerPathsAreUri = true;
     private boolean clientLinesStartAt1 = true;
     private boolean clientColumnsStartAt1 = true;
@@ -103,6 +105,10 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     @Override
     public void setDebuggerLinesStartAt1(boolean debuggerLinesStartAt1) {
         this.debuggerLinesStartAt1 = debuggerLinesStartAt1;
+    }
+
+    public boolean isDebuggerColumnsStartAt1() {
+        return debuggerColumnStartAt1;
     }
 
     @Override

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2020 Microsoft Corporation and others.
+ * Copyright (c) 2017-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,6 +54,8 @@ public interface IDebugAdapterContext {
     boolean isClientColumnsStartAt1();
 
     void setClientColumnsStartAt1(boolean clientColumnsStartAt1);
+
+    boolean isDebuggerColumnsStartAt1();
 
     boolean isClientPathsAreUri();
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ISourceLookUpProvider.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ISourceLookUpProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Microsoft Corporation and others.
+ * Copyright (c) 2017-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,11 +12,31 @@
 package com.microsoft.java.debug.core.adapter;
 
 import com.microsoft.java.debug.core.DebugException;
+import com.microsoft.java.debug.core.JavaBreakpointLocation;
+import com.microsoft.java.debug.core.protocol.Types.SourceBreakpoint;
 
 public interface ISourceLookUpProvider extends IProvider {
     boolean supportsRealtimeBreakpointVerification();
 
+    /**
+     * Deprecated, please use {@link #getBreakpointLocations(String, SourceBreakpoint[])} instead.
+     */
+    @Deprecated
     String[] getFullyQualifiedName(String uri, int[] lines, int[] columns) throws DebugException;
+
+    /**
+     * Given a set of source breakpoint locations with line and column numbers,
+     * verify if they are valid breakpoint locations. If it's a valid location,
+     * resolve its enclosing class name, method name and signature (for method
+     * breakpoint) and all possible inline breakpoint locations in that line.
+     *
+     * @param sourceUri
+     *                  the source file uri
+     * @param sourceBreakpoints
+     *                  the source breakpoints with line and column numbers
+     * @return Locations of Breakpoints containing context class and method information.
+     */
+    JavaBreakpointLocation[] getBreakpointLocations(String sourceUri, SourceBreakpoint[] sourceBreakpoints) throws DebugException;
 
     /**
      * Given a fully qualified class name and source file path, search the associated disk source file.

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/BreakpointLocationsRequestHander.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/BreakpointLocationsRequestHander.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.microsoft.java.debug.core.adapter.handler;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.microsoft.java.debug.core.IBreakpoint;
+import com.microsoft.java.debug.core.adapter.AdapterUtils;
+import com.microsoft.java.debug.core.adapter.ErrorCode;
+import com.microsoft.java.debug.core.adapter.IDebugAdapterContext;
+import com.microsoft.java.debug.core.adapter.IDebugRequestHandler;
+import com.microsoft.java.debug.core.protocol.Requests;
+import com.microsoft.java.debug.core.protocol.Responses;
+import com.microsoft.java.debug.core.protocol.Messages.Response;
+import com.microsoft.java.debug.core.protocol.Requests.Arguments;
+import com.microsoft.java.debug.core.protocol.Requests.BreakpointLocationsArguments;
+import com.microsoft.java.debug.core.protocol.Requests.Command;
+import com.microsoft.java.debug.core.protocol.Types.BreakpointLocation;
+
+/**
+ * The breakpointLocations request returns all possible locations for source breakpoints in a given range.
+ * Clients should only call this request if the corresponding capability supportsBreakpointLocationsRequest is true.
+ */
+public class BreakpointLocationsRequestHander implements IDebugRequestHandler {
+
+    @Override
+    public List<Command> getTargetCommands() {
+        return Arrays.asList(Requests.Command.BREAKPOINTLOCATIONS);
+    }
+
+    @Override
+    public CompletableFuture<Response> handle(Command command, Arguments arguments, Response response,
+            IDebugAdapterContext context) {
+        BreakpointLocationsArguments bpArgs = (BreakpointLocationsArguments) arguments;
+        String sourceUri = SetBreakpointsRequestHandler.normalizeSourcePath(bpArgs.source, context);
+        // When breakpoint source path is null or an invalid file path, send an ErrorResponse back.
+        if (StringUtils.isBlank(sourceUri)) {
+            throw AdapterUtils.createCompletionException(
+                String.format("Failed to get BreakpointLocations. Reason: '%s' is an invalid path.", bpArgs.source.path),
+                ErrorCode.SET_BREAKPOINT_FAILURE);
+        }
+
+        int debuggerLine = AdapterUtils.convertLineNumber(bpArgs.line, context.isClientLinesStartAt1(), context.isDebuggerLinesStartAt1());
+        IBreakpoint[] breakpoints = context.getBreakpointManager().getBreakpoints(sourceUri);
+        BreakpointLocation[] locations = new BreakpointLocation[0];
+        for (int i = 0; i < breakpoints.length; i++) {
+            if (breakpoints[i].getLineNumber() == debuggerLine && ArrayUtils.isNotEmpty(
+                    breakpoints[i].sourceLocation().availableBreakpointLocations())) {
+                locations = Stream.of(breakpoints[i].sourceLocation().availableBreakpointLocations()).map(location -> {
+                    BreakpointLocation newLocaiton = new BreakpointLocation();
+                    newLocaiton.line = AdapterUtils.convertLineNumber(location.line,
+                                    context.isDebuggerLinesStartAt1(), context.isClientLinesStartAt1());
+                    newLocaiton.column = AdapterUtils.convertColumnNumber(location.column,
+                                    context.isDebuggerColumnsStartAt1(), context.isClientColumnsStartAt1());
+                    newLocaiton.endLine = AdapterUtils.convertLineNumber(location.endLine,
+                                    context.isDebuggerLinesStartAt1(), context.isClientLinesStartAt1());
+                    newLocaiton.endColumn = AdapterUtils.convertColumnNumber(location.endColumn,
+                                    context.isDebuggerColumnsStartAt1(), context.isClientColumnsStartAt1());
+                    return newLocaiton;
+                }).toArray(BreakpointLocation[]::new);
+                break;
+            }
+        }
+
+        response.body = new Responses.BreakpointLocationsResponseBody(locations);
+        return CompletableFuture.completedFuture(response);
+    }
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/InitializeRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/InitializeRequestHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Microsoft Corporation and others.
+ * Copyright (c) 2017-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -64,6 +64,7 @@ public class InitializeRequestHandler implements IDebugRequestHandler {
         caps.supportsDataBreakpoints = true;
         caps.supportsFunctionBreakpoints = true;
         caps.supportsClipboardContext = true;
+        caps.supportsBreakpointLocationsRequest = true;
         response.body = caps;
         return CompletableFuture.completedFuture(response);
     }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Requests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.java.debug.core.protocol.Types.DataBreakpoint;
+import com.microsoft.java.debug.core.protocol.Types.Source;
 
 /**
  * The request arguments types defined by VSCode Debug Protocol.
@@ -376,6 +377,42 @@ public class Requests {
         }
     }
 
+    /**
+     * Arguments for breakpointLocations request.
+     */
+    public static class BreakpointLocationsArguments extends Arguments {
+        /**
+         * The source location of the breakpoints; either `source.path` or
+         * `source.reference` must be specified.
+         */
+        public Source source;
+
+        /**
+         * Start line of range to search possible breakpoint locations in. If only the
+         * line is specified, the request returns all possible locations in that line.
+         */
+        public int line;
+
+        /**
+         * Start column of range to search possible breakpoint locations in. If no
+         * start column is given, the first column in the start line is assumed.
+         */
+        public int column;
+
+        /**
+         * End line of range to search possible breakpoint locations in. If no end
+         * line is given, then the end line is assumed to be the start line.
+         */
+        public int endLine;
+
+        /**
+         * End column of range to search possible breakpoint locations in. If no end
+         * column is given, then it is assumed to be in the last column of the end
+         * line.
+         */
+        public int endColumn;
+    }
+
     public static enum Command {
         INITIALIZE("initialize", InitializeArguments.class),
         LAUNCH("launch", LaunchArguments.class),
@@ -411,6 +448,7 @@ public class Requests {
         INLINEVALUES("inlineValues", InlineValuesArguments.class),
         REFRESHVARIABLES("refreshVariables", RefreshVariablesArguments.class),
         PROCESSID("processId", Arguments.class),
+        BREAKPOINTLOCATIONS("breakpointLocations", BreakpointLocationsArguments.class),
         UNSUPPORTED("", Arguments.class);
 
         private String command;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Responses.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Responses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017-2019 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package com.microsoft.java.debug.core.protocol;
 
 import java.util.List;
 
+import com.microsoft.java.debug.core.protocol.Types.BreakpointLocation;
 import com.microsoft.java.debug.core.protocol.Types.DataBreakpointAccessType;
 import com.microsoft.java.debug.core.protocol.Types.ExceptionBreakMode;
 import com.microsoft.java.debug.core.protocol.Types.ExceptionDetails;
@@ -279,6 +280,21 @@ public class Responses {
             this.description = description;
             this.accessTypes = accessTypes;
             this.canPersist = canPersist;
+        }
+    }
+
+    /**
+     * Response to breakpointLocations request.
+     * Contains possible locations for source breakpoints.
+     */
+    public static class BreakpointLocationsResponseBody extends ResponseBody {
+        /**
+         * Sorted set of possible breakpoint locations.
+         */
+        public BreakpointLocation[] breakpoints;
+
+        public BreakpointLocationsResponseBody(BreakpointLocation[] breakpoints) {
+            this.breakpoints = breakpoints;
         }
     }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Types.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Types.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017-2019 Microsoft Corporation and others.
+* Copyright (c) 2017-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import java.nio.file.Paths;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * The data types defined by VSCode Debug Protocol.
+ * The data types defined by Debug Adapter Protocol.
  */
 public class Types {
     public static class Message {
@@ -200,6 +200,9 @@ public class Types {
         }
     }
 
+    /**
+     * Properties of a breakpoint or logpoint passed to the setBreakpoints request.
+     */
     public static class SourceBreakpoint {
         public int line;
         public int column;
@@ -207,7 +210,9 @@ public class Types {
         public String condition;
         public String logMessage;
 
-        public SourceBreakpoint() {
+        public SourceBreakpoint(int line, int column) {
+            this.line = line;
+            this.column = column;
         }
 
         /**
@@ -300,6 +305,46 @@ public class Types {
         }
     }
 
+    /**
+     * Properties of a breakpoint location returned from the breakpointLocations request.
+     */
+    public static class BreakpointLocation {
+        /**
+         * Start line of breakpoint location.
+         */
+        public int line;
+
+        /**
+         * The start column of breakpoint location.
+         */
+        public int column;
+
+        /**
+         * The end line of breakpoint location if the location covers a range.
+         */
+        public int endLine;
+
+        /**
+         * The end column of breakpoint location if the location covers a range.
+         */
+        public int endColumn;
+
+        public BreakpointLocation() {
+        }
+
+        public BreakpointLocation(int line, int column) {
+            this.line = line;
+            this.column = column;
+        }
+
+        public BreakpointLocation(int line, int column, int endLine, int endColumn) {
+            this.line = line;
+            this.column = column;
+            this.endLine = endLine;
+            this.endColumn = endColumn;
+        }
+    }
+
     public static class CompletionItem {
         public String label;
         public String text;
@@ -386,5 +431,7 @@ public class Types {
         public boolean supportsDataBreakpoints;
         public boolean supportsClipboardContext;
         public boolean supportsFunctionBreakpoints;
+        // https://microsoft.github.io/debug-adapter-protocol/specification#Requests_BreakpointLocations
+        public boolean supportsBreakpointLocationsRequest;
     }
 }

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
@@ -34,13 +34,9 @@ public class LambdaExpressionLocator extends ASTVisitor {
 
     @Override
     public boolean visit(LambdaExpression node) {
-        // we only support inline breakpoints which are added before the expression part of the
-        // lambda. And we don't support lambda blocks since they can be debugged using line
-        // breakpoints.
         if (column > -1) {
             int startPosition = node.getStartPosition();
-            int endPosition = node.getBody().getStartPosition();
-            int offset = this.compilationUnit.getPosition(line, column);
+            int breakOffset = this.compilationUnit.getPosition(line, column);
             // lambda on same line:
             // list.stream().map(i -> i + 1);
             //
@@ -48,7 +44,10 @@ public class LambdaExpressionLocator extends ASTVisitor {
             // list.stream().map(user
             // -> user.isSystem() ? new SystemUser(user) : new EndUser(user));
 
-            if (offset >= startPosition && offset <= endPosition) {
+            // Since the debugger supports BreakpointLocations Request to hint user
+            // about possible inline breakpoint locations, we will only support
+            // inline breakpoints added where a lambda expression begins.
+            if (breakOffset == startPosition) {
                 this.lambdaMethodBinding = node.resolveMethodBinding();
                 this.found = true;
                 this.lambdaExpression = node;


### PR DESCRIPTION
What this PR does:
- Support BreakpointLocations DAP Request, this can visualize the locations where inline breakpoints can be added. Closes microsoft/vscode-java-debug#1193.
![image](https://user-images.githubusercontent.com/14052197/190965636-d2794c99-115e-4d72-8269-b7f6e9d38efe.png)

- Show an extra column cursor when an inline breakpoint is hit. Closes microsoft/vscode-java-debug#1202
![image](https://user-images.githubusercontent.com/14052197/190965801-d94fc7db-f3e3-405b-a26d-6e2d337bc430.png)

- Line breakpoint will only break on the first location on that line. If the line contains other lambdas, you can add an inline breakpoint to break on other locations.