### PR TITLE
Conditional Breakpoint got error code in reply:504

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IStackFrameManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IStackFrameManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Microsoft Corporation and others.
+ * Copyright (c) 2017-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,15 @@ public interface IStackFrameManager {
     StackFrame[] reloadStackFrames(ThreadReference thread);
 
     /**
+     * Refresh all stackframes from jdi thread.
+     *
+     * @param thread the jdi thread
+     * @param force Whether to load the whole frames if the thread's stackframes haven't been cached.
+     * @return all the stackframes in the specified thread
+     */
+    StackFrame[] reloadStackFrames(ThreadReference thread, boolean force);
+
+    /**
      * Refersh the stackframes starting from the specified depth and length.
      *
      * @param thread the jdi thread
@@ -48,4 +57,9 @@ public interface IStackFrameManager {
      * @param thread the jdi thread
      */
     void clearStackFrames(ThreadReference thread);
+
+    /**
+     * Clear the whole stackframes cache.
+     */
+    void clearStackFrames();
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/StackFrameManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/StackFrameManager.java
@@ -32,10 +32,19 @@ public class StackFrameManager implements IStackFrameManager {
 
     @Override
     public synchronized StackFrame[] reloadStackFrames(ThreadReference thread) {
+        return reloadStackFrames(thread, true);
+    }
+
+    @Override
+    public synchronized StackFrame[] reloadStackFrames(ThreadReference thread, boolean force) {
         return threadStackFrameMap.compute(thread.uniqueID(), (key, old) -> {
             try {
                 if (old == null || old.length == 0) {
-                    return thread.frames().toArray(new StackFrame[0]);
+                    if (force) {
+                        return thread.frames().toArray(new StackFrame[0]);
+                    } else {
+                        return new StackFrame[0];
+                    }
                 } else {
                     return thread.frames(0, old.length).toArray(new StackFrame[0]);
                 }
@@ -70,5 +79,10 @@ public class StackFrameManager implements IStackFrameManager {
     @Override
     public synchronized void clearStackFrames(ThreadReference thread) {
         threadStackFrameMap.remove(thread.uniqueID());
+    }
+
+    @Override
+    public synchronized void clearStackFrames() {
+        threadStackFrameMap.clear();
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ThreadsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ThreadsRequestHandler.java
@@ -159,11 +159,13 @@ public class ThreadsRequestHandler implements IDebugRequestHandler {
             context.getExceptionManager().removeException(arguments.threadId);
             allThreadsContinued = false;
             DebugUtility.resumeThread(thread);
+            context.getStackFrameManager().clearStackFrames(thread);
             checkThreadRunningAndRecycleIds(thread, context);
         } else {
             context.getStepResultManager().removeAllMethodResults();
             context.getExceptionManager().removeAllExceptions();
             resumeVM(context);
+            context.getStackFrameManager().clearStackFrames();
             context.getRecyclableIdPool().removeAllObjects();
         }
         response.body = new Responses.ContinueResponseBody(allThreadsContinued);
@@ -175,6 +177,7 @@ public class ThreadsRequestHandler implements IDebugRequestHandler {
         context.getExceptionManager().removeAllExceptions();
         resumeVM(context);
         context.getProtocolServer().sendEvent(new Events.ContinuedEvent(arguments.threadId, true));
+        context.getStackFrameManager().clearStackFrames();
         context.getRecyclableIdPool().removeAllObjects();
         return CompletableFuture.completedFuture(response);
     }
@@ -280,6 +283,7 @@ public class ThreadsRequestHandler implements IDebugRequestHandler {
                 context.getExceptionManager().removeException(threadId);
                 DebugUtility.resumeThread(thread, suspends);
                 context.getProtocolServer().sendEvent(new Events.ContinuedEvent(threadId));
+                context.getStackFrameManager().clearStackFrames(thread);
                 checkThreadRunningAndRecycleIds(thread, context);
             }
         } catch (ObjectCollectedException ex) {

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/eval/JdtEvaluationProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/eval/JdtEvaluationProvider.java
@@ -317,7 +317,7 @@ public class JdtEvaluationProvider implements IEvaluationProvider {
                 @Override
                 protected synchronized void invokeComplete(int restoreTimeout) {
                     super.invokeComplete(restoreTimeout);
-                    context.getStackFrameManager().reloadStackFrames(thread);
+                    context.getStackFrameManager().reloadStackFrames(thread, false);
                 }
             });
         }


### PR DESCRIPTION
Fixes microsoft/vscode-java-debug#1250

In old behavior, conditional breakpoint will store some stale stackframes in the cache so that its length doesn't match the new conditional breakpoint's stackframe length.

Fix: conditional breakpoint doesn't need to reload the stack frames if the thread's stackframes are not used before.