### PR TITLE
prioritize lookup the project source code during debugging

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/InlineValueHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/InlineValueHandler.java
@@ -166,7 +166,7 @@ public class InlineValueHandler {
      */
     private static Position getPosition(IBuffer buffer, int offset) {
         int[] result = JsonRpcHelpers.toLine(buffer, offset);
-        if (result == null && result.length < 1) {
+        if (result == null || result.length < 1) {
             return new Position(-1, -1);
         }
 

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtUtils.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtUtils.java
@@ -213,10 +213,10 @@ public class JdtUtils {
         projects.stream().distinct().map(project -> JdtUtils.getJavaProject(project))
             .filter(javaProject -> javaProject != null && javaProject.exists())
             .forEach(javaProject -> {
-                // Add source containers associated with the project's runtime classpath entries.
-                containers.addAll(Arrays.asList(getSourceContainers(javaProject, calculated)));
                 // Add source containers associated with the project's source folders.
                 containers.add(new JavaProjectSourceContainer(javaProject));
+                // Add source containers associated with the project's runtime classpath entries.
+                containers.addAll(Arrays.asList(getSourceContainers(javaProject, calculated)));
             });
 
         return containers.toArray(new ISourceContainer[0]);


### PR DESCRIPTION
If there is an identical class file A .java in the project and the dependency, then the A .java under the project should be found first during debugging.

Fixes microsoft/vscode-java-debug#1215