### PR TITLE
Add LSP4J 0.20.0 to the target platform.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,9 +154,9 @@
     </profiles>
     <repositories>
         <repository>
-            <id>202112</id>
+            <id>202212</id>
             <layout>p2</layout>
-            <url>https://download.eclipse.org/releases/2021-12/202112081000/</url>
+            <url>https://download.eclipse.org/releases/2022-12/202212071000/</url>
         </repository>
         <repository>
             <id>oss.sonatype.org</id>
@@ -179,6 +179,11 @@
             <id>orbit</id>
             <layout>p2</layout>
             <url>https://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository/</url>
+        </repository>
+        <repository>
+            <id>lsp4j</id>
+            <layout>p2</layout>
+            <url>https://download.eclipse.org/lsp4j/updates/releases/0.20.0/</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
- Fixed #472 
- JDT-LS now uses LSP4J 0.20.0, which is not available in Orbit or the main release repository