### PR TITLE
Improve lambda method discovery Fixes: #477

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/BindingUtils.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/BindingUtils.java
@@ -35,7 +35,15 @@ public final class BindingUtils {
      */
     public static String getMethodName(IMethodBinding binding, boolean fromKey) {
         if (fromKey) {
-            return LambdaLocationLocatorHelper.toMethodName(binding);
+            String key = binding.getKey();
+            int dotAt = key.indexOf('.');
+            int end = key.indexOf('<', dotAt);
+            if (end == -1) {
+                end = key.indexOf('(');
+            } else {
+                end = Math.min(end, key.indexOf('('));
+            }
+            return key.substring(dotAt + 1, end);
         } else {
             return binding.getName();
         }

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/BindingUtils.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/BindingUtils.java
@@ -12,10 +12,12 @@
 package com.microsoft.java.debug;
 
 import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.internal.debug.core.breakpoints.LambdaLocationLocatorHelper;
 
 /**
  * Utility methods around working with JDT Bindings.
  */
+@SuppressWarnings("restriction")
 public final class BindingUtils {
     private BindingUtils() {
 
@@ -33,46 +35,21 @@ public final class BindingUtils {
      */
     public static String getMethodName(IMethodBinding binding, boolean fromKey) {
         if (fromKey) {
-            String key = binding.getKey();
-            int dotAt = key.indexOf('.');
-            int end = key.indexOf('<', dotAt);
-            if (end == -1) {
-                end = key.indexOf('(');
-            } else {
-                end = Math.min(end, key.indexOf('('));
-            }
-            return key.substring(dotAt + 1, end);
+            return LambdaLocationLocatorHelper.toMethodName(binding);
         } else {
             return binding.getName();
         }
     }
 
     /**
-     * Returns the method signature of the method represented by the binding. Since
-     * this implementation use the {@link IMethodBinding#getKey()} to extract the
-     * signature from, the method name must be passed in.
+     * Returns the method signature of the method represented by the binding
+     * including the synthetic outer locals.
      *
      * @param binding the binding which the signature must be resolved for.
-     * @param name    the name of the method.
-     * @return the signature or null if the signature could not be resolved from the
-     *         key.
+     * @return the signature or null if the signature could not be resolved.
      */
-    public static String toSignature(IMethodBinding binding, String name) {
-        // use key for now until JDT core provides a public API for this.
-        // "Ljava/util/Arrays;.asList<T:Ljava/lang/Object;>([TT;)Ljava/util/List<TT;>;"
-        // "([Ljava/lang/String;)V|Ljava/lang/InterruptedException;"
-        String signatureString = binding.getKey();
-        if (signatureString != null) {
-            name = "." + name;
-            int index = signatureString.indexOf(name);
-            if (index > -1) {
-                int exceptionIndex = signatureString.indexOf("|", signatureString.lastIndexOf(")"));
-                if (exceptionIndex > -1) {
-                    return signatureString.substring(index + name.length(), exceptionIndex);
-                }
-                return signatureString.substring(index + name.length());
-            }
-        }
-        return null;
+    public static String toSignature(IMethodBinding binding) {
+        return LambdaLocationLocatorHelper.toMethodSignature(binding);
     }
+
 }

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/BreakpointLocationLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/BreakpointLocationLocator.java
@@ -46,7 +46,7 @@ public class BreakpointLocationLocator
         if (this.methodBinding == null) {
             return null;
         }
-        return BindingUtils.toSignature(this.methodBinding, getMethodName());
+        return BindingUtils.toSignature(this.methodBinding);
     }
 
     /**

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
@@ -71,7 +71,7 @@ public class LambdaExpressionLocator extends ASTVisitor {
         if (!this.found) {
             return null;
         }
-        return BindingUtils.toSignature(this.lambdaMethodBinding, getMethodName());
+        return BindingUtils.toSignature(this.lambdaMethodBinding);
     }
 
     /**

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
@@ -284,8 +284,9 @@ public class JdtSourceLookUpProvider implements ISourceLookUpProvider {
                 parser.setProject(JavaCore.create(resource.getProject()));
             } else {
                 parser.setEnvironment(new String[0], new String[0], null, true);
-                parser.setUnitName(Paths.get(filePath).getFileName().toString());
             }
+            parser.setUnitName(Paths.get(filePath).getFileName().toString());
+            
             /**
              * See the java doc for { @link ASTParser#setSource(char[]) },
              * the user need specify the compiler options explicitly.

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
@@ -286,7 +286,6 @@ public class JdtSourceLookUpProvider implements ISourceLookUpProvider {
                 parser.setEnvironment(new String[0], new String[0], null, true);
             }
             parser.setUnitName(Paths.get(filePath).getFileName().toString());
-            
             /**
              * See the java doc for { @link ASTParser#setSource(char[]) },
              * the user need specify the compiler options explicitly.


### PR DESCRIPTION
The issue seems to be when resolving lambda method for reactive operators, the binding resolver is not the default binding resolvers which actually resolves the lambda method. 

It seems. the AST construction effects which binding resolver is used at runtime in the node. Therefore switched to the using cache AST when available which seems to resolved the issue. Will do some more testing.