### PR TITLE
Improve support for multiline lambda expressions. Fix #489

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
@@ -49,7 +49,17 @@ public class LambdaExpressionLocator extends ASTVisitor {
             // Since the debugger supports BreakpointLocations Request to hint user
             // about possible inline breakpoint locations, we will only support
             // inline breakpoints added where a lambda expression begins.
-            if (breakOffset == startPosition || (!exactMatch && breakOffset > startPosition && breakOffset < (startPosition + node.getLength()))) {
+
+            // the second expression tries to find lambda expression which are formatted as
+            // list.stream().map(
+            // user -> user.isSystem() ? new SystemUser(user) : new EndUser(user));
+            // since lambda is on a different line it will not match the first expression.
+
+            if (breakOffset == startPosition
+                    || (!exactMatch
+                            && this.compilationUnit.getLineNumber(breakOffset) == this.compilationUnit
+                                    .getLineNumber(startPosition)
+                            && breakOffset < (startPosition + node.getLength()))) {
                 this.lambdaMethodBinding = node.resolveMethodBinding();
                 this.found = true;
                 this.lambdaExpression = node;

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/LambdaExpressionLocator.java
@@ -25,11 +25,13 @@ public class LambdaExpressionLocator extends ASTVisitor {
 
     private IMethodBinding lambdaMethodBinding;
     private LambdaExpression lambdaExpression;
+    private boolean exactMatch;
 
-    public LambdaExpressionLocator(CompilationUnit compilationUnit, int line, int column) {
+    public LambdaExpressionLocator(CompilationUnit compilationUnit, int line, int column, boolean exactMatch) {
         this.compilationUnit = compilationUnit;
         this.line = line;
         this.column = column;
+        this.exactMatch = exactMatch;
     }
 
     @Override
@@ -47,7 +49,7 @@ public class LambdaExpressionLocator extends ASTVisitor {
             // Since the debugger supports BreakpointLocations Request to hint user
             // about possible inline breakpoint locations, we will only support
             // inline breakpoints added where a lambda expression begins.
-            if (breakOffset == startPosition) {
+            if (breakOffset == startPosition || (!exactMatch && breakOffset > startPosition && breakOffset < (startPosition + node.getLength()))) {
                 this.lambdaMethodBinding = node.resolveMethodBinding();
                 this.found = true;
                 this.lambdaExpression = node;


### PR DESCRIPTION
The patch tries to see if the line breakpoint falls on a lambda expression which is wrapped into a new line by the formatter.
Therefore when trying to see if the current line falls inside a lambda we use a range match instead of a exact match of the start position. For this purpose a new constructor parameter is added into Lambda Locator class to switch between this mode.