### PR TITLE
Fix generic return type lambda breakpoint issue. Fix #1359

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
@@ -343,14 +343,14 @@ public class Breakpoint implements IBreakpoint {
         for (int i = 0; i < chars.length; i++) {
             char c = chars[i];
             if (c == '<') {
-                depth ++;
+                depth++;
                 append = (depth == 0);
             }
             if (append) {
                 builder.append(c);
             }
             if (c == '>') {
-                depth --;
+                depth--;
                 append = (depth == 0);
             }
         }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
@@ -335,24 +335,23 @@ public class Breakpoint implements IBreakpoint {
         return location;
     }
 
-    private String toNoneGeneric(String genericSig) {
+    static String toNoneGeneric(String genericSig) {
         StringBuilder builder = new StringBuilder();
-        boolean skip = false;
+        boolean append = true;
+        int depth = 0;
         char[] chars = genericSig.toCharArray();
         for (int i = 0; i < chars.length; i++) {
             char c = chars[i];
             if (c == '<') {
-                skip = true;
+                depth ++;
+                append = (depth == 0);
             }
-            if (!skip) {
+            if (append) {
                 builder.append(c);
             }
-            if (skip && c == '>') {
-                if (i + 2 < chars.length) {
-                    skip = chars[i + 2] == '>';
-                } else {
-                    skip = false;
-                }
+            if (c == '>') {
+                depth --;
+                append = (depth == 0);
             }
         }
         return builder.toString();

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
@@ -338,7 +338,9 @@ public class Breakpoint implements IBreakpoint {
     private String toNoneGeneric(String genericSig) {
         StringBuilder builder = new StringBuilder();
         boolean skip = false;
-        for (char c : genericSig.toCharArray()) {
+        char[] chars = genericSig.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            char c = chars[i];
             if (c == '<') {
                 skip = true;
             }
@@ -346,7 +348,11 @@ public class Breakpoint implements IBreakpoint {
                 builder.append(c);
             }
             if (skip && c == '>') {
-                skip = false;
+                if (i + 2 < chars.length) {
+                    skip = chars[i + 2] == '>';
+                } else {
+                    skip = false;
+                }
             }
         }
         return builder.toString();

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
@@ -325,13 +325,31 @@ public class Breakpoint implements IBreakpoint {
         for (Method method : methods) {
             if (!method.isAbstract() && !method.isNative()
                     && methodName.equals(method.name())
-                    && (methodSiguature.equals(method.genericSignature()) || methodSiguature.equals(method.signature()))) {
+                    && (methodSiguature.equals(method.genericSignature()) || methodSiguature.equals(method.signature())
+                            || toNoneGeneric(methodSiguature).equals(method.signature()))) {
                 location = method.location();
                 break;
             }
         }
 
         return location;
+    }
+
+    private String toNoneGeneric(String genericSig) {
+        StringBuilder builder = new StringBuilder();
+        boolean skip = false;
+        for (char c : genericSig.toCharArray()) {
+            if (c == '<') {
+                skip = true;
+            }
+            if (!skip) {
+                builder.append(c);
+            }
+            if (skip && c == '>') {
+                skip = false;
+            }
+        }
+        return builder.toString();
     }
 
     private List<Location> findLocaitonsOfLine(Method method, int lineNumber) {

--- a/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/BreakpointTest.java
+++ b/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/BreakpointTest.java
@@ -1,0 +1,17 @@
+package com.microsoft.java.debug.core;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class BreakpointTest {
+    @Test
+    public void testToNoneGeneric() {
+        assertEquals("Ljava.util.List;", Breakpoint.toNoneGeneric("Ljava.util.List<java.lang.String;>;"));
+        assertEquals("(Ljava/util/Map;)Ljava/util/Map;", Breakpoint.toNoneGeneric(
+                "(Ljava/util/Map<Ljava/lang/String;Ljava/util/List<Ljava/lang/Integer;>;>;)Ljava/util/Map<Ljava/lang/String;Ljava/util/List<Ljava/lang/Integer;>;>;"));
+        assertEquals("(Ljava/util/Map;)Ljava/util/Map;",
+                Breakpoint.toNoneGeneric(
+                        "(Ljava/util/Map<Ljava/util/List<Ljava/lang/Integer;>;Ljava/util/List<Ljava/lang/Integer;>;>;)Ljava/util/Map<Ljava/util/List<Ljava/lang/Integer;>;Ljava/util/List<Ljava/lang/Integer;>;>;"));
+    }
+}


### PR DESCRIPTION
The fix tries to compare the runtime lambda method signature with none generic version of the method signature found from AST traversal as a additional comparison to what is there.