### PR TITLE
Add extensibility points to DebugAdapter and ProtocolServer

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
@@ -102,7 +102,7 @@ public class DebugAdapter implements IDebugAdapter {
         }
     }
 
-    private void initialize() {
+    protected void initialize() {
         // Register request handlers.
         // When there are multiple handlers registered for the same request, follow the rule "first register, first execute".
         registerHandler(new InitializeRequestHandler());
@@ -141,15 +141,15 @@ public class DebugAdapter implements IDebugAdapter {
         registerHandlerForNoDebug(new ProcessIdHandler());
     }
 
-    private void registerHandlerForDebug(IDebugRequestHandler handler) {
+    protected void registerHandlerForDebug(IDebugRequestHandler handler) {
         registerHandler(requestHandlersForDebug, handler);
     }
 
-    private void registerHandlerForNoDebug(IDebugRequestHandler handler) {
+    protected void registerHandlerForNoDebug(IDebugRequestHandler handler) {
         registerHandler(requestHandlersForNoDebug, handler);
     }
 
-    private void registerHandler(IDebugRequestHandler handler) {
+    protected void registerHandler(IDebugRequestHandler handler) {
         registerHandler(requestHandlersForDebug, handler);
         registerHandler(requestHandlersForNoDebug, handler);
     }
@@ -165,4 +165,5 @@ public class DebugAdapter implements IDebugAdapter {
             handlerList.add(handler);
         }
     }
+
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterFactory.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterFactory.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package com.microsoft.java.debug.core.adapter;
+
+import com.microsoft.java.debug.core.protocol.IProtocolServer;
+
+@FunctionalInterface
+public interface IDebugAdapterFactory {
+    public IDebugAdapter create(IProtocolServer server);
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProtocolServer.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProtocolServer.java
@@ -53,6 +53,20 @@ public class ProtocolServer extends AbstractProtocolServer {
     }
 
     /**
+     * Constructs a protocol server instance based on the given input stream and output stream.
+     * @param input
+     *              the input stream
+     * @param output
+     *              the output stream
+     * @param debugAdapterFactory
+     *              factory to create debug adapter that implements DAP communication
+     */
+    public ProtocolServer(InputStream input, OutputStream output, IDebugAdapterFactory debugAdapterFactory) {
+        super(input, output);
+        debugAdapter = debugAdapterFactory.create(this);
+    }
+
+    /**
      * A while-loop to parse input data and send output data constantly.
      */
     @Override


### PR DESCRIPTION
## Context

I'm building a Java DAP server based on `com.microsoft.java.debug.core` for our internal projects based on Buck. The goals is to enable debugging without relying on Eclipse LSP. So I'm customizing the part that is resolving source locations based on our internal language tooling and the dependency graph knowledge available in Buck. 

`com.microsoft.java.debug.core` works really well for me as I'm able to completely reuse JDWP <-> DAP interaction while replacing providers with my own implementation. This works quite well.

Additionally our binaries are quite customised so I'd like to also provide custom implementations for "initialize", "launch" and "setFunctionalBreakpoints" requests without necessarily rewriting `ProtocolServer` and `DebugAdapter`

This PR is enabling me to inherit `DebugAdapter` (and inject to `ProtocolServer`) to customize handlers that get executed  without doing weird hacks with reflection or rewriting both of those types