### PR TITLE
Extend ISourceLookUpProvider to be able to specify whether the source is Local (VSCode) or Remote(DAP Server) 

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapterContext.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.ArrayUtils;
 public class DebugAdapterContext implements IDebugAdapterContext {
     private static final int MAX_CACHE_ITEMS = 10000;
     private final StepFilters defaultFilters = new StepFilters();
-    private Map<String, String> sourceMappingCache = Collections.synchronizedMap(new LRUCache<>(MAX_CACHE_ITEMS));
+    private Map<String, Source> sourceMappingCache = Collections.synchronizedMap(new LRUCache<>(MAX_CACHE_ITEMS));
     private IProviderContext providerContext;
     private IProtocolServer server;
 
@@ -212,7 +212,7 @@ public class DebugAdapterContext implements IDebugAdapterContext {
     }
 
     @Override
-    public Map<String, String> getSourceLookupCache() {
+    public Map<String, Source> getSourceLookupCache() {
         return sourceMappingCache;
     }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/IDebugAdapterContext.java
@@ -85,7 +85,7 @@ public interface IDebugAdapterContext {
 
     void setVariableFormatter(IVariableFormatter variableFormatter);
 
-    Map<String, String> getSourceLookupCache();
+    Map<String, Source> getSourceLookupCache();
 
     void setDebuggeeEncoding(Charset encoding);
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ISourceLookUpProvider.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ISourceLookUpProvider.java
@@ -8,7 +8,6 @@
  * Contributors:
  *     Microsoft Corporation - initial API and implementation
  *******************************************************************************/
-
 package com.microsoft.java.debug.core.adapter;
 
 import java.util.List;
@@ -42,17 +41,30 @@ public interface ISourceLookUpProvider extends IProvider {
     JavaBreakpointLocation[] getBreakpointLocations(String sourceUri, SourceBreakpoint[] sourceBreakpoints) throws DebugException;
 
     /**
-     * Given a fully qualified class name and source file path, search the associated disk source file.
-     *
-     * @param fullyQualifiedName
-     *                  the fully qualified class name (e.g. com.microsoft.java.debug.core.adapter.ISourceLookUpProvider).
-     * @param sourcePath
-     *                  the qualified source file path (e.g. com\microsoft\java\debug\core\adapter\ISourceLookupProvider.java).
-     * @return the associated source file uri.
+     * Deprecated, please use {@link #getSource(String, String)} instead.
      */
+    @Deprecated
     String getSourceFileURI(String fullyQualifiedName, String sourcePath);
 
     String getSourceContents(String uri);
+
+    /**
+     * Retrieves a {@link Source} object representing the source code associated with the given fully qualified class name and source file path.
+     * The implementation of this interface can determine a source is "local" or "remote".
+     * In case of "remote" a follow up "source" request will be issued by the client
+     *
+     * @param fullyQualifiedName
+     *                  the fully qualified class name,
+     *                  e.g., "com.microsoft.java.debug.core.adapter.ISourceLookUpProvider".
+     * @param sourcePath
+     *                  the qualified source file path,
+     *                  e.g., "com/microsoft/java/debug/core/adapter/ISourceLookupProvider.java".
+     * @return A {@link Source} object encapsulating the source file URI obtained from
+     *                  {@link #getSourceFileURI(String, String)} and the source type as {@link SourceType#LOCAL}.
+     */
+    default Source getSource(String fullyQualifiedName, String sourcePath) {
+        return new Source(getSourceFileURI(fullyQualifiedName, sourcePath), SourceType.LOCAL);
+    }
 
     /**
      * Returns the Java runtime that the specified project's build path used.

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/Source.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/Source.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.microsoft.java.debug.core.adapter;
+
+public class Source {
+    public final String uri;
+    public final SourceType type;
+
+    public Source(String uri, SourceType type) {
+        this.uri = uri;
+        this.type = type;
+    }
+
+    public String getUri() {
+        return this.uri;
+    }
+
+    public SourceType getType() {
+        return this.type;
+    }
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/SourceType.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/SourceType.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package com.microsoft.java.debug.core.adapter;
+
+public enum SourceType {
+    REMOTE,
+    LOCAL
+}


### PR DESCRIPTION
## Context

I'm building a DAP server based on `core` package. I.e. without eclipse plugin. Currently it's impossible to set "sourceReference" when returning types in "stacktrace" request. 

Having a distinction between Local and Remote sources allows an implementation of ISourceLookUpProvider to instruct the underlying request handlers whether a follow up with "source" request and have it served via `getSourceContents`

This is also ABI compatible with whoever could implement ISourceLookUpProvider already as current logic is identical to SourceType.Local

## Test Plan
I've tested this works with my DAP server
