### PR TITLE
Fix the step-into target on multi line expression. Fix #519

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StepRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StepRequestHandler.java
@@ -451,7 +451,7 @@ public class StepRequestHandler implements IDebugRequestHandler {
         // expression which is wrapped.
         return originalMethod.equals(currentMethod)
                 && (original.lineNumber() == current.lineNumber()
-                        || (targetStepIn != null && targetStepIn.lineStart >= current.lineNumber()));
+                        || (targetStepIn != null && targetStepIn.lineEnd >= current.lineNumber()));
     }
 
     /**

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StepRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StepRequestHandler.java
@@ -268,7 +268,8 @@ public class StepRequestHandler implements IDebugRequestHandler {
                                 } else if (currentStackDepth == threadState.stackDepth) {
                                     // If the ending step location is same as the original location where the step into operation is originated,
                                     // do another step of the same kind.
-                                    if (isSameLocation(currentStepLocation, threadState.stepLocation)) {
+                                    if (isSameLocation(currentStepLocation, threadState.stepLocation,
+                                            threadState.targetStepIn)) {
                                         context.getStepResultManager().removeMethodResult(threadId);
                                         threadState.pendingStepRequest = DebugUtility.createStepIntoRequest(thread,
                                             context.getStepFilters().allowClasses,
@@ -438,15 +439,19 @@ public class StepRequestHandler implements IDebugRequestHandler {
         return true;
     }
 
-    private boolean isSameLocation(Location original, Location current) {
+    private boolean isSameLocation(Location current, Location original, MethodInvocation targetStepIn) {
         if (original == null || current == null) {
             return false;
         }
 
         Method originalMethod = original.method();
         Method currentMethod = current.method();
+        // if the lines doesn't match, check if the current line is still behind the
+        // target if a target exist. This handles where the target is part of a
+        // expression which is wrapped.
         return originalMethod.equals(currentMethod)
-            && original.lineNumber() == current.lineNumber();
+                && (original.lineNumber() == current.lineNumber()
+                        || (targetStepIn != null && targetStepIn.lineStart >= current.lineNumber()));
     }
 
     /**

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/MethodInvocationLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/MethodInvocationLocator.java
@@ -71,7 +71,11 @@ public class MethodInvocationLocator extends ASTVisitor {
 
     @Override
     public boolean visit(TypeDeclaration node) {
-        return shouldVisitNode(node);
+        // when root type declaration doesn't ends with a empty line, the end position
+        // for the root type returned from getLineNumber becomes -1. Therefore the
+        // shouldVisitNode fails, so the extra check unit.getRoot() == node.getRoot() is
+        // added.
+        return unit.getRoot() == node.getRoot() || shouldVisitNode(node);
     }
 
     @Override

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/MethodInvocationLocator.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/MethodInvocationLocator.java
@@ -71,11 +71,7 @@ public class MethodInvocationLocator extends ASTVisitor {
 
     @Override
     public boolean visit(TypeDeclaration node) {
-        // when root type declaration doesn't ends with a empty line, the end position
-        // for the root type returned from getLineNumber becomes -1. Therefore the
-        // shouldVisitNode fails, so the extra check unit.getRoot() == node.getRoot() is
-        // added.
-        return unit.getRoot() == node.getRoot() || shouldVisitNode(node);
+        return shouldVisitNode(node);
     }
 
     @Override
@@ -221,7 +217,7 @@ public class MethodInvocationLocator extends ASTVisitor {
 
     private boolean shouldVisitNode(ASTNode node) {
         int start = unit.getLineNumber(node.getStartPosition());
-        int end = unit.getLineNumber(node.getStartPosition() + node.getLength());
+        int end = unit.getLineNumber(node.getStartPosition() + node.getLength() - 1);
 
         if (line >= start && line <= end) {
             return true;


### PR DESCRIPTION
The fix try to compare the current line number against the target MethodInvocation start line if the debugger lines doesn't match because the current frame is at a wrapped line even though we are executing the same expression.