### PR TITLE
Update target platform dependencies

### DIFF
--- a/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target
+++ b/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target
@@ -17,7 +17,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2023-12/202311171000/"/>
+            <repository location="https://download.eclipse.org/releases/2023-12/202312061001/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>


### PR DESCRIPTION
Fixes build errors. The old location is no longer available:

https://download.eclipse.org/releases/2023-12/202311171000/ returns 404
