### PR TITLE
Remove the obselete parameter '-Djava.compiler=NONE' from launching command

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/AdvancedLaunchingConnector.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/AdvancedLaunchingConnector.java
@@ -195,7 +195,6 @@ public class AdvancedLaunchingConnector extends SocketLaunchingConnectorImpl imp
 
         StringBuilder execString = new StringBuilder();
         execString.append("\"" + javaHome + slash + "bin" + slash + javaExec + "\"");
-        execString.append(" -Djava.compiler=NONE");
         execString.append(" -Xrunjdwp:transport=dt_socket,address=" + address + ",server=n,suspend=" + (suspend ? "y" : "n"));
         if (javaOptions != null) {
             execString.append(" " + javaOptions);


### PR DESCRIPTION
Launching a Java app in the CONSOLE with java 23, it still reports some warning `OpenJDK 64-Bit Server VM warning: The java.compiler system property is obsolete and no longer supported, use -Xint`.