### PR TITLE
Update lsp4j dependency to version 0.23.1

### DIFF
--- a/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target
+++ b/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target
@@ -36,7 +36,7 @@
             <repository location="https://download.eclipse.org/jdtls/snapshots/repository/latest/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.22.0/"/>
+           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/"/>
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
         </location>
     </locations>


### PR DESCRIPTION
New version of jdtls core requires lsp4j 0.23 or greater.

With 0.22.0 the build currently fails with the following error:

```
[ERROR] Cannot resolve target definition:
[ERROR]   Software being installed: org.eclipse.jdt.ls.core 1.39.0.202408021530
[ERROR]   Missing requirement: org.eclipse.jdt.ls.core 1.39.0.202408021530 requires 'osgi.bundle; org.eclipse.lsp4j [0.23.0.0,0.24.0)' but it could not be found
[ERROR]
```