### PR TITLE
Update eclipse to use v4.33

### DIFF
--- a/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target
+++ b/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target
@@ -15,7 +15,7 @@
             <unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240613-1800"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.33/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>


### PR DESCRIPTION
Using current version of [4.33-I-builds](https://github.com/microsoft/java-debug/blob/3691f3b5f2cae05b06b43333dc435c172e27f1a8/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target#L18) yields this error when trying to `./mvnw clean install`:
```
Failed to load p2 metadata repository from location https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240613-1800:
No repository found at https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240613-1800.
```

Tried to use just [4.33](https://download.eclipse.org/eclipse/updates/4.33/) instead and the error is gone now.
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Java Debug Server for Visual Studio Code :: Parent 0.53.0:
[INFO]
[INFO] Java Debug Server for Visual Studio Code :: Parent . SUCCESS [  0.046 s]
[INFO] Java Debug Server for Visual Studio Code :: Debugger Core SUCCESS [  3.488 s]
[INFO] Java Debug Server for Visual Studio Code :: Debugger Plugin SUCCESS [  4.642 s]
[INFO] Java Debug Server for Visual Studio Code :: P2 Update site SUCCESS [  0.420 s]
[INFO] Java Debug Server for Visual Studio Code :: Target Platform SUCCESS [  0.004 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```