### PR TITLE
Update target platform to more closely follow JDT-LS.

### DIFF
--- a/com.microsoft.java.debug.plugin/.classpath
+++ b/com.microsoft.java.debug.plugin/.classpath
@@ -7,7 +7,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.11.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.19.0.jar"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry exported="true" kind="lib" path="lib/rxjava-2.2.21.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/reactive-streams-1.0.4.jar"/>

--- a/com.microsoft.java.debug.plugin/META-INF/MANIFEST.MF
+++ b/com.microsoft.java.debug.plugin/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.commons.lang3,
  org.eclipse.lsp4j,
  com.google.guava
-Bundle-ClassPath: lib/commons-io-2.11.0.jar,
+Bundle-ClassPath: lib/commons-io-2.19.0.jar,
  .,
  lib/rxjava-2.2.21.jar,
  lib/reactive-streams-1.0.4.jar,

--- a/com.microsoft.java.debug.plugin/pom.xml
+++ b/com.microsoft.java.debug.plugin/pom.xml
@@ -51,7 +51,7 @@
                         <artifactItem>
                             <groupId>commons-io</groupId>
                             <artifactId>commons-io</artifactId>
-                            <version>2.11.0</version>
+                            <version>2.19.0</version>
                         </artifactItem>
                         <artifactItem>
                             <groupId>com.microsoft.java</groupId>

--- a/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target
+++ b/com.microsoft.java.debug.target/com.microsoft.java.debug.tp.target
@@ -1,43 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="Java Debug" sequenceNumber="39">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
-            <unit id="com.google.gson.source" version="2.7.0.v20170129-0911"/>
-            <unit id="com.ibm.icu.base" version="58.2.0.v20170418-1837"/>
-            <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-            <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
-            <repository location="https://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.equinox.core.sdk.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.33/"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
-            <unit id="org.eclipse.jdt.core" version="0.0.0"/>
-            <unit id="org.eclipse.jdt.apt.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/jdtls/jdt-core-incubator/snapshots/"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2024-03/"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>
-            <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22/"/>
+            <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.36-I-builds/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/latest/"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/"/>
-           <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.jdt" version="0.0.0"/>
+            <unit id="org.eclipse.buildship.core" version="0.0.0"/>
+            <unit id="com.google.gson" version="0.0.0"/>
+            <unit id="com.google.guava" version="0.0.0"/>
+            <unit id="org.apache.commons.lang3" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/latest"/>
         </location>
     </locations>
 </target>


### PR DESCRIPTION
- Update Apache Commons IO from 2.11.0 to 2.19.0

java-debug is a bundle contributed into the JDT-LS runtime. This means that it has no control over any dependencies it dos not contribute into the runtime itself (all of them). So when java-debug defines a target platform with dependencies that don't reference the same ones JDT-LS does, it is masking any potential runtime problems. This is the same issue we ran into on LSP4MP / quarkus-ls. The project will compile just fine and fail at runtime because the target platform is not reflective of runtime.

The solution is to reference the exact bundles JDT-LS is using (ie. the latest ones), at https://download.eclipse.org/jdtls/snapshots/repository/latest/plugins/ .

- [ ] Need to verify this by running it but it compiles and tests seem to run just fine.