### PR TITLE
Handle unavailable sources in compliance with DAP spec

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StackTraceRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StackTraceRequestHandler.java
@@ -220,8 +220,10 @@ public class StackTraceRequestHandler implements IDebugRequestHandler {
             } else {
                 // For other unavailable method, such as lambda expression's built-in methods run/accept/apply,
                 // display "Unknown Source" in the Call Stack View.
-                clientSource = null;
+                clientSource = new Types.Source("Unknown Source", "unknown", 0);
             }
+            // DAP specifies lineNumber to be set to 0 when unavailable
+            clientLineNumber = 0;
         } else if (DebugSettings.getCurrent().debugSupportOnDecompiledSource == Switch.ON
                 && clientSource != null && clientSource.path != null) {
             // Align the original line with the decompiled line.


### PR DESCRIPTION
Fixes #605 
- when the source is not available, e.g. for native methods or lambdas, return 0 in the `line` field of `StackFrame` as prescribed by the [Debug Adapter Protocol Specification](https://microsoft.github.io/debug-adapter-protocol/specification#:~:text=/**%0A%20%20%20*%20The%20line%20within%20the%20source%20of%20the%20frame.%20If%20the%20source%20attribute%20is%20missing%0A%20%20%20*%20or%20doesn%27t%20exist%2C%20%60line%60%20is%200%20and%20should%20be%20ignored%20by%20the%20client.%0A%20%20%20*/%0A%20%20line%3A%20number%3B)
- set the display value of the source path to "unknown" explicitly instead of returning `null` source. This is not required by the spec, but friendly for clients