### PR TITLE
Set source to null when unavailable in StackTrace

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StackTraceRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StackTraceRequestHandler.java
@@ -220,7 +220,7 @@ public class StackTraceRequestHandler implements IDebugRequestHandler {
             } else {
                 // For other unavailable method, such as lambda expression's built-in methods run/accept/apply,
                 // display "Unknown Source" in the Call Stack View.
-                clientSource = new Types.Source("Unknown Source", "unknown", 0);
+                clientSource = null;
             }
             // DAP specifies lineNumber to be set to 0 when unavailable
             clientLineNumber = 0;


### PR DESCRIPTION
As noted by @mfussenegger in https://github.com/microsoft/java-debug/pull/609 it's probably more correct and in the spirit of the spec to keep the `source` as `null` when it is not unavailable instead of setting it to a special value, especially since it would break nvim-dap otherwise. 