### PR TITLE
Fix lspFrame.source NPE on stackTrace request

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StackTraceRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/StackTraceRequestHandler.java
@@ -114,7 +114,7 @@ public class StackTraceRequestHandler implements IDebugRequestHandler {
                     result.add(lspFrame);
                     frameReference.setSource(lspFrame.source);
                     int jdiLineNumber = AdapterUtils.convertLineNumber(jdiFrame.lineNumber, context.isDebuggerLinesStartAt1(), context.isClientLinesStartAt1());
-                    if (jdiLineNumber != lspFrame.line && lspFrame.source != null) {
+                    if (jdiLineNumber >= 0 && jdiLineNumber != lspFrame.line) {
                         decompiledClasses.add(lspFrame.source.path);
                     }
                 }


### PR DESCRIPTION
Follow up to:

- https://github.com/microsoft/java-debug/pull/614
- https://github.com/microsoft/java-debug/pull/609

With the change to set the line number to 0 the jdiLineNumber !=
lspFrame.line comparison can evaluate to true:

    dap> lspFrame
    Types$StackFrame@78
      column: 1
      id: 6
      line: 0
      name: "0x000000002f0bc000.invokeVirtual(Object,Object)"
      presentationHint: "subtle"
      source: null

    dap> jdiLineNumber
    -1

`source` being null caused an NPE

Fixes https://github.com/microsoft/java-debug/issues/612