### PR TITLE
perf: Exclude Map.Entry from lazy loading to show key:value inline

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/VariableDetailUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/VariableDetailUtils.java
@@ -163,6 +163,13 @@ public class VariableDetailUtils {
             return false;
         }
         String inheritedType = findInheritedType(value, COLLECTION_TYPES);
+        // Map.Entry should not use lazy loading because its details computation
+        // (getKey + getValue) is lightweight and showing "key:value" inline
+        // significantly improves UX for large Maps. See
+        // https://github.com/microsoft/vscode-java-debug/issues/1605
+        if (Objects.equals(inheritedType, ENTRY_TYPE)) {
+            return false;
+        }
         if (inheritedType == null && !containsToStringMethod((ObjectReference) value)) {
             return false;
         }


### PR DESCRIPTION
Map.Entry objects were incorrectly treated as lazy-loading candidates because they are included in COLLECTION_TYPES. This caused the debugger to display entries as 'HashMap$Node@id' instead of showing the actual key:value details inline.

Map.Entry's details computation (getKey + getValue) is lightweight, so eager evaluation is safe and significantly improves UX when debugging large Maps.

Fixes https://github.com/microsoft/vscode-java-debug/issues/1605