### PR TITLE
fix: handle NoSuchMethodError for isMainMethodCandidate() on older JD…

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainClassHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainClassHandler.java
@@ -241,6 +241,13 @@ public class ResolveMainClassHandler {
             return method.isMainMethod();
         } catch (JavaModelException e) {
             // do nothing
+        } catch (NoSuchMethodError e) {
+            // isMainMethodCandidate() was added in JDT Core 3.36, fall back to isMainMethod()
+            try {
+                return method.isMainMethod();
+            } catch (JavaModelException ex) {
+                // do nothing
+            }
         }
 
         return false;

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainMethodHandler.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/ResolveMainMethodHandler.java
@@ -112,9 +112,13 @@ public class ResolveMainMethodHandler {
         boolean allowInstanceMethod = isInstanceMainMethodSupported(type);
         List<IMethod> methods = new ArrayList<>();
         for (IMethod method : type.getMethods()) {
-            if (method instanceof SourceMethod
-                && ((SourceMethod) method).isMainMethodCandidate()) {
-                methods.add(method);
+            try {
+                if (method instanceof SourceMethod
+                    && ((SourceMethod) method).isMainMethodCandidate()) {
+                    methods.add(method);
+                }
+            } catch (NoSuchMethodError e) {
+                // isMainMethodCandidate() was added in JDT Core 3.36, skip if unavailable
             }
 
             if (method.isMainMethod()) {


### PR DESCRIPTION
…T Core

Catch NoSuchMethodError when calling SourceMethod.isMainMethodCandidate() in ResolveMainClassHandler and ResolveMainMethodHandler. This method was added in JDT Core 3.36 and is unavailable on older versions, causing the debugger to fail entirely when resolving main classes.

Fixes microsoft/vscode-java-debug#1598