### PR TITLE
Use JDTUtils.toUri() for decompiled class file URIs

### DIFF
--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtSourceLookUpProvider.java
@@ -466,15 +466,7 @@ public class JdtSourceLookUpProvider implements ISourceLookUpProvider {
     }
 
     private static String getFileURI(IClassFile classFile) {
-        String packageName = classFile.getParent().getElementName();
-        String jarName = classFile.getParent().getParent().getElementName();
-        try {
-            return new URI(JDT_SCHEME, "contents", PATH_SEPARATOR + jarName + PATH_SEPARATOR + packageName
-                    + PATH_SEPARATOR + classFile.getElementName(), classFile.getHandleIdentifier(), null)
-                    .toASCIIString();
-        } catch (URISyntaxException e) {
-            return null;
-        }
+        return JDTUtils.toUri(classFile);
     }
 
     private static String getFileURI(IResource resource) {


### PR DESCRIPTION
Replace manual jdt:// URI construction in getFileURI(IClassFile) with JDTUtils.toUri(classFile) to align with eclipse.jdt.ls PR #3666.

This ensures the debugger generates the same URI format as the language server, fixing the issue where classes with source code are opened twice (once as .java, once as .class) during debugging.

Fixes microsoft/java-debug#623
Related: eclipse-jdtls/eclipse.jdt.ls#3729