### PR TITLE
Added attributes to VariablePresentationHint as specified in protocol definition

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -82,7 +82,7 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
      * single-threaded JDWP request processing strategy,
      * a single JDWP latency is about 10ms.
      */
-    static final long USABLE_JDWP_LATENCY = 10/**ms*/;
+    static final long USABLE_JDWP_LATENCY = 10/*ms*/;
 
     @Override
     public List<Command> getTargetCommands() {
@@ -370,10 +370,12 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
                 referenceId = context.getRecyclableIdPool().addObject(containerNode.getThreadId(), varProxy);
             }
 
+            String[] rawAttributes = extractAttributes(javaVariable);
+
             Types.Variable typedVariables = new Types.Variable(name, valueString, typeString, referenceId, evaluateName);
             typedVariables.indexedVariables = Math.max(indexedVariables, 0);
-            if (varProxy != null && varProxy.isLazyVariable()) {
-                typedVariables.presentationHint = new VariablePresentationHint(true);
+            if ((varProxy != null && varProxy.isLazyVariable()) || (rawAttributes.length > 0)) {
+                typedVariables.presentationHint = new VariablePresentationHint(varProxy == null || varProxy.isLazyVariable(), rawAttributes);
             }
 
             if (detailsValue != null) {
@@ -389,6 +391,28 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
         response.body = new Responses.VariablesResponseBody(list);
 
         return CompletableFuture.completedFuture(response);
+    }
+
+    private String[] extractAttributes(Variable variable) {
+        final List<String> attributes = new ArrayList<>();
+        if (variable.field != null) {
+            if (variable.field.isStatic()) {
+                attributes.add("static");
+            }
+            if (variable.field.isFinal()) {
+                // static final fields are compile-time constants in Java
+                if (variable.field.isStatic()) {
+                    attributes.add("constant");
+                }
+                attributes.add("readOnly");
+            }
+        }
+        // local 'final' variables get inlined by the compiler and do not appear
+        if (variable.value instanceof StringReference) {
+            attributes.add("rawString");
+        }
+
+        return attributes.toArray(new String[0]);
     }
 
     private boolean supportsLogicStructureView(IDebugAdapterContext context) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -65,6 +65,8 @@ import com.sun.jdi.StackFrame;
 import com.sun.jdi.StringReference;
 import com.sun.jdi.Type;
 import com.sun.jdi.Value;
+import com.sun.jdi.PrimitiveType;
+import com.sun.jdi.ClassNotLoadedException;
 
 public class VariablesRequestHandler implements IDebugRequestHandler {
     protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
@@ -375,7 +377,7 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
             Types.Variable typedVariables = new Types.Variable(name, valueString, typeString, referenceId, evaluateName);
             typedVariables.indexedVariables = Math.max(indexedVariables, 0);
             if ((varProxy != null && varProxy.isLazyVariable()) || (rawAttributes.length > 0)) {
-                typedVariables.presentationHint = new VariablePresentationHint(varProxy == null || varProxy.isLazyVariable(), rawAttributes);
+                typedVariables.presentationHint = new VariablePresentationHint(varProxy != null && varProxy.isLazyVariable(), rawAttributes);
             }
 
             if (detailsValue != null) {
@@ -400,14 +402,22 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
                 attributes.add("static");
             }
             if (variable.field.isFinal()) {
-                // static final fields are compile-time constants in Java
-                if (variable.field.isStatic()) {
+                // static final Primitive or StringRef fields are compile-time constants in Java
+                boolean isPrimitive;
+                try {
+                    isPrimitive = variable.field.type() instanceof PrimitiveType;
+                } catch (ClassNotLoadedException e) { /* type() not yet loaded indicates some ReferenceType */
+                    isPrimitive = false;
+                }
+                boolean canBeTrueConstant = (isPrimitive || variable.field instanceof StringReference);
+                if (variable.field.isStatic() && canBeTrueConstant) {
                     attributes.add("constant");
                 }
                 attributes.add("readOnly");
             }
         }
         // local 'final' variables get inlined by the compiler and do not appear
+
         if (variable.value instanceof StringReference) {
             attributes.add("rawString");
         }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Types.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/Types.java
@@ -49,19 +49,13 @@ public class Types {
         /**
          * Constructs a StackFrame with the given information.
          *
-         * @param id
-         *          the stack frame id
-         * @param name
-         *          the stack frame name
-         * @param src
-         *          source info of the stack frame
-         * @param ln
-         *          line number of the stack frame
-         * @param col
-         *          column number of the stack frame
-         * @param presentationHint
-         *          An optional hint for how to present this frame in the UI.
-         *          Values: 'normal', 'label', 'subtle'
+         * @param id               the stack frame id
+         * @param name             the stack frame name
+         * @param src              source info of the stack frame
+         * @param ln               line number of the stack frame
+         * @param col              column number of the stack frame
+         * @param presentationHint An optional hint for how to present this frame in the UI.
+         *                         Values: 'normal', 'label', 'subtle'
          */
         public StackFrame(int id, String name, Source src, int ln, int col, String presentationHint) {
             this.id = id;
@@ -408,9 +402,11 @@ public class Types {
 
     public static class VariablePresentationHint {
         public boolean lazy;
+        public String[] attributes;
 
-        public VariablePresentationHint(boolean lazy) {
+        public VariablePresentationHint(boolean lazy, String[] attributes) {
             this.lazy = lazy;
+            this.attributes = attributes;
         }
     }
 


### PR DESCRIPTION
Added "static", "constant", "readOnly" and "rawString" as attributes of VariablePresentationHint as defined in the protocol specification.

Necessary to distinguish static variables from locals.