### PR TITLE
Handle VM disconnection gracefully and reorder termination logic

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
@@ -117,7 +117,11 @@ public class DebugSession implements IDebugSession {
 
     @Override
     public void detach() {
-        vm.dispose();
+        try {
+            vm.dispose();
+        } catch (VMDisconnectedException ex) {
+            // ignore — VM already disconnected (e.g. process was terminated first)
+        }
     }
 
     @Override

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestHandler.java
@@ -26,8 +26,8 @@ public class DisconnectRequestHandler extends AbstractDisconnectRequestHandler {
         IDebugSession debugSession = context.getDebugSession();
         if (debugSession != null) {
             if (disconnectArguments.terminateDebuggee && !context.isAttached()) {
-                debugSession.detach();
                 debugSession.terminate();
+                debugSession.detach();
             } else {
                 debugSession.detach();
             }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestHandler.java
@@ -26,8 +26,11 @@ public class DisconnectRequestHandler extends AbstractDisconnectRequestHandler {
         IDebugSession debugSession = context.getDebugSession();
         if (debugSession != null) {
             if (disconnectArguments.terminateDebuggee && !context.isAttached()) {
-                debugSession.terminate();
-                debugSession.detach();
+                try {
+                    debugSession.terminate();
+                } finally {
+                    debugSession.detach();
+                }
             } else {
                 debugSession.detach();
             }


### PR DESCRIPTION
After the changes in #620 the stop button wasn't working properly. The action wasn't executed and the process just kept running.

The `terminate()` now is called before `detach()` when terminating the debuggee, ensuring proper shutdown sequence.