### PR TITLE
fix: correct method location typo

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/Breakpoint.java
@@ -329,16 +329,16 @@ public class Breakpoint implements IBreakpoint {
         List<CompletableFuture<Location>> futures = new ArrayList<>();
         for (ReferenceType refType : refTypes) {
             if (async()) {
-                futures.add(AsyncJdwpUtils.supplyAsync(() -> findMethodLocaiton(refType, methodName, methodSiguature)));
+                futures.add(AsyncJdwpUtils.supplyAsync(() -> findMethodLocation(refType, methodName, methodSiguature)));
             } else {
-                futures.add(CompletableFuture.completedFuture(findMethodLocaiton(refType, methodName, methodSiguature)));
+                futures.add(CompletableFuture.completedFuture(findMethodLocation(refType, methodName, methodSiguature)));
             }
         }
 
         return AsyncJdwpUtils.all(futures);
     }
 
-    private Location findMethodLocaiton(ReferenceType refType, String methodName, String methodSiguature) {
+    private Location findMethodLocation(ReferenceType refType, String methodName, String methodSiguature) {
         List<Method> methods = refType.methods();
         Location location = null;
         for (Method method : methods) {


### PR DESCRIPTION
## Summary
- Rename the private helper `findMethodLocaiton` to `findMethodLocation`.
- Update the two call sites in `Breakpoint` to use the corrected spelling.

Fixes #512.

## Testing
- `rg -n "findMethodLocaiton|findMethodLocation" com.microsoft.java.debug.core\src\main\java\com\microsoft\java\debug\core\Breakpoint.java`
- `git diff --check`

`mvn` was not available in my local environment, so I could not run the Maven build.

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.